### PR TITLE
fix generation of pattern match strategies

### DIFF
--- a/org.metaborg.meta.lang.nabl/trans/generation/propositions.str
+++ b/org.metaborg.meta.lang.nabl/trans/generation/propositions.str
@@ -76,11 +76,8 @@ rules
       key := <new-key(|"match")> r
     ; <iset-add(|MATCH_RULE(key, p, v, var*))> r
       
-  new-key(|base) =
-    iset-elements
-  ; length
-  ; <conc-strings> (base, <int-to-string>)
-   
+  new-key(|base) = <newname> base
+  
 overlays
 	
 	TASK(s, t)      = TASK(s, [], t)


### PR DESCRIPTION
All rewrite rules generated from `where ... => Pattern(x, y)` use "match0" to identify the associated pattern. This leads to problems when you have more than one pattern match in a NaBL where clause.