### PR TITLE
Add syntax proposal for relational definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,53 @@
 In Spoofax, name bindings are specified in NaBL.
 NaBL stands for *Name Binding Language* and the acronym is pronounced 'enable'.
 Name binding is specified in terms of
-  namespaces, 
-  binding instances (name declarations), 
+  namespaces,
+  binding instances (name declarations),
   bound instances (name references),
   scopes and
   imports.
 
 ## Documentation
 
-We maintain the NaBL documentation in [our documentation repository](https://github.com/metaborg/doc/tree/master/meta-languages/nabl). 
+We maintain the NaBL documentation in [our documentation repository](https://github.com/metaborg/doc/tree/master/meta-languages/nabl).
+
+## Contributing
+
+### Project structure
+
+The project consists of several modules.
+
+```
+org.metaborg.meta.nabl2.shared
+              |
+org.metaborg.meta.nabl2.lang
+              |
+org.metaborg.meta.nabl2.runtime
+              |
+org.metaborg.meta.nabl2.java
+```
+
+* `shared`:
+
+  All constructors and rules that exist in shared are used both during compilation with `lang` as well as during running using `runtime`.
+
+* `lang`:
+
+  The `lang` module is a codegenerator that, based on the constraint definitions by the user language, generates stratego rules that exist in `runtime`.
+
+* `runtime`:
+
+  The `runtime` module defines all stratego implementation to run the actual constraint generation based on the constraints that were defined in the user language.
+
+* `java`:
+
+  The constraints generated on runtime by `runtime` are solved using the `java` implementation.
+
+### Extending nabl2
+
+If you want to extend the Nabl2 language, you have several options.
+
+1. If you need to extend the syntax of Nabl2 with for example sugar, you also need to implement the required transformations in `org.metaborg.meta.nabl2.lang/trans/nabl2/lang`.
+These transformations define a mapping from Nabl2 constructs to stratego calls.
+1. If the new syntax also requires new functionality, you will need to implement the functionality in `java` and create corresponding stratego definitions in `runtime`.
+Do not directly call `java`-like functions inside generated stratego code from an user language nabl2 definition.

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
@@ -4,6 +4,8 @@ imports
  
   nabl2/shared/common/CTerms
   nabl2/shared/common/Identifiers
+  nabl2/shared/common/Names
+  nabl2/shared/common/ScopeGraph
   nabl2/shared/constraints/Base
 
   nabl2/lang/common/Identifiers
@@ -37,6 +39,10 @@ context-free syntax
   RuleClause             = Constraint
   RuleClause             = NewScopes
   RuleClause.CGenRecurse = <<CGenRuleRefTop> [[ <Var> <CGenParamsTerm> <CGenTypeTerm> ]]>
+  RuleClause.ForAll		 = <
+  	forall <Occurrence>:<Var> in <Names> =\> {
+  		<{RuleClause ",\n"}+>.
+  	}>
 
 
 context-free syntax

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/rules/CGen.sdf3
@@ -4,8 +4,6 @@ imports
  
   nabl2/shared/common/CTerms
   nabl2/shared/common/Identifiers
-  nabl2/shared/common/Names
-  nabl2/shared/common/ScopeGraph
   nabl2/shared/constraints/Base
 
   nabl2/lang/common/Identifiers
@@ -39,10 +37,6 @@ context-free syntax
   RuleClause             = Constraint
   RuleClause             = NewScopes
   RuleClause.CGenRecurse = <<CGenRuleRefTop> [[ <Var> <CGenParamsTerm> <CGenTypeTerm> ]]>
-  RuleClause.ForAll		 = <
-  	forall <Occurrence>:<Var> in <Names> =\> {
-  		<{RuleClause ",\n"}+>.
-  	}>
 
 
 context-free syntax

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
@@ -20,7 +20,7 @@ context-free syntax
 
 context-free syntax
 
-  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <RelationDefPatterns>>
+  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <RelationPatterns>>
 
   RelationOption = Reflexivity
   RelationOption = Symmetry
@@ -29,24 +29,9 @@ context-free syntax
   RelationType.TypeSort =
   RelationType          = <: <SortRef> * <SortRef>>
 
-  RelationDefPatterns = <{ <{RelationDefPattern ",\n"}*> }>
-  RelationDefPatterns      = {ast("[]")}
+  RelationPatterns = <{ <{RelationPattern "\n"}*> }>
+  RelationPatterns      = {ast("[]")}
   
-  RelationDefPattern = VariancePattern
-  RelationDefPattern = RelationPattern
- 
-  RelationPattern.Relation = <
-  	<RelationDefVariant> <RelationBuildOp> <RelationDefVariant> := {
-   		<{RuleClause ",\n"}+>.
-   	}>
-  
-  VarIds = {VarId ","}*
-  
-  
- syntax 
-  
-  RelationDefVariant-CF.DefVariant = OpId-LEX "(" LAYOUT?-CF VarIds-CF LAYOUT?-CF ")"
- 
- lexical syntax
+lexical syntax
  
   Keyword = "relations"

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
@@ -20,7 +20,7 @@ context-free syntax
 
 context-free syntax
 
-  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <Patterns>>
+  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <RelationDefPatterns>>
 
   RelationOption = Reflexivity
   RelationOption = Symmetry
@@ -29,11 +29,11 @@ context-free syntax
   RelationType.TypeSort =
   RelationType          = <: <SortRef> * <SortRef>>
 
-  Patterns = <{ <{Pattern ",\n"}*> }>
-  Patterns      = {ast("[]")}
+  RelationDefPatterns = <{ <{RelationDefPattern ",\n"}*> }>
+  RelationDefPatterns      = {ast("[]")}
   
-  Pattern = VariancePattern
-  Pattern = RelationPattern
+  RelationDefPattern = VariancePattern
+  RelationDefPattern = RelationPattern
  
   RelationPattern.Relation = <
   	<RelationDefVariant> <RelationBuildOp> <RelationDefVariant> := {

--- a/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.lang/syntax/nabl2/lang/signatures/Relations.sdf3
@@ -5,6 +5,7 @@ imports
   nabl2/shared/common/Identifiers
   nabl2/shared/common/Relations
   nabl2/shared/common/Sorts
+  nabl2/lang/rules/CGen
 
 template options
 
@@ -19,7 +20,7 @@ context-free syntax
 
 context-free syntax
 
-  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <VariancePatterns>>
+  RelationDef.RelationDef = <<{RelationOption ", "}*> <Relation> <RelationType> <Patterns>>
 
   RelationOption = Reflexivity
   RelationOption = Symmetry
@@ -28,8 +29,23 @@ context-free syntax
   RelationType.TypeSort =
   RelationType          = <: <SortRef> * <SortRef>>
 
-  VariancePatterns      = <{ <{VariancePattern ",\n"}*> }>
-  VariancePatterns      = {ast("[]")}
+  Patterns = <{ <{Pattern ",\n"}*> }>
+  Patterns      = {ast("[]")}
+  
+  Pattern = VariancePattern
+  Pattern = RelationPattern
+ 
+  RelationPattern.Relation = <
+  	<RelationDefVariant> <RelationBuildOp> <RelationDefVariant> := {
+   		<{RuleClause ",\n"}+>.
+   	}>
+  
+  VarIds = {VarId ","}*
+  
+  
+ syntax 
+  
+  RelationDefVariant-CF.DefVariant = OpId-LEX "(" LAYOUT?-CF VarIds-CF LAYOUT?-CF ")"
  
  lexical syntax
  

--- a/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/generation/cgen/injections.str
+++ b/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/generation/cgen/injections.str
@@ -6,6 +6,7 @@ imports
   
   signatures/nabl2/lang/common/-
   signatures/nabl2/lang/rules/-
+  signatures/nabl2/lang/signatures/-
   signatures/nabl2/shared/constraints/-
   generation/nabl2/lang/cgen/-
   generation/nabl2/lang/-

--- a/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/generation/cgen/signatures/relations.str
+++ b/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/generation/cgen/signatures/relations.str
@@ -3,6 +3,7 @@ module nabl2/lang/generation/cgen/signatures/relations
 imports
 
   libstrc
+  libspoofax/stratego/debug
   nabl2/lang/generation/cgen/-
   signatures/nabl2/shared/common/-
   signatures/nabl2/shared/constraints/-
@@ -10,7 +11,7 @@ imports
   signatures/nabl2/lang/signatures/-
   nabl2/lang/util/stratego
 
-rules
+rules 
 
   signature-to-str:
     Relations(_) -> []
@@ -19,7 +20,7 @@ rules
     section* -> [Rules(relstr*)]
     with reldef* := <filter(?Signature(<id>));concat;
                      filter(?Relations(<id>));concat;
-                     map(\ RelationDef(opt*,name,sort,var*) -> (name,opt*,var*) \)> section*;
+                     map(\ RelationDef(opt*,name,sort,var*) -> (name,opt*,var*) \); debug0> section*;
          if [_|_] := reldef* then
            relterm* := <map(explode(injection-to-term))> reldef*;
            relstr* := [ |[ nabl2--custom-relations = !~List(relterm*) ]| ]

--- a/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/util/stratego.str
+++ b/org.metaborg.meta.nabl2.lang/trans/nabl2/lang/util/stratego.str
@@ -14,6 +14,8 @@ rules
 
   mapseq(s): [] -> |[ id ]|
   
+  explode = let g(s) = fail in explode(g) end
+  
   explode(g) = g(explode(g)) <+ explode-generic(g)
 
   explode-generic(g): s -> Str(s)

--- a/org.metaborg.meta.nabl2.shared/syntax/nabl2/shared/common/Relations.sdf3
+++ b/org.metaborg.meta.nabl2.shared/syntax/nabl2/shared/common/Relations.sdf3
@@ -2,6 +2,7 @@ module nabl2/shared/common/Relations
 
 imports
 
+  nabl2/shared/constraints/Base
   nabl2/shared/common/Identifiers
 
 template options
@@ -24,6 +25,11 @@ context-free syntax
   RelationRef.DefaultRelation =
   RelationRef                 = Relation
 
+  RelationPattern.RelationPattern = <
+  	(<RelationDefVariant>, <RelationDefVariant>) := <Constraint>.>
+  	
+  VarIds = {VarId ","}*
+
 syntax
 
   RelationBuildOp-CF = "<" RelationRef-CF "!"
@@ -34,6 +40,8 @@ syntax
 
   OpRelation-CF.DefaultRelation =
   OpRelation-CF.Relation        = RelationId-LEX "."
+  
+  RelationDefVariant-CF.DefVariant = OpId-LEX "(" LAYOUT?-CF VarIds-CF LAYOUT?-CF ")"
 
 context-free syntax
 

--- a/org.metaborg.meta.nabl2.shared/syntax/nabl2/shared/constraints/Base.sdf3
+++ b/org.metaborg.meta.nabl2.shared/syntax/nabl2/shared/constraints/Base.sdf3
@@ -4,6 +4,8 @@ imports
 
   nabl2/shared/common/Identifiers
   nabl2/shared/common/Messages
+  nabl2/shared/common/Names
+  nabl2/shared/common/ScopeGraph
 
 template options
 
@@ -13,6 +15,14 @@ context-free syntax
 
   Constraint.CTrue   = <true <MessagePosition>>
   Constraint.CFalse  = <false <Message>>
+  
+  Constraint.Exists  = <
+  	exists <VarId>@<Occurrence> in <Names> =\> <Constraint>>
+  
+  Constraint.ForAll  = <
+  	forall <VarId>@<Occurrence> in <Names> =\> <Constraint>>
+  	
+  Constraint.CList   = <(<{Constraint ",\n"}+>)>
 
 lexical syntax
 


### PR DESCRIPTION
To be able to define structural type relational definitions,
we propose this syntax for defining patterns on type relations.

The syntax consists of 2 additions:
  - A new RuleClause:
```
"forall" Occurrence ":" Var "in" Names "=> {"
    {RuleClause ",\n"}+ "."
"}"
```

that can iterate over all occurrences in a namespace. It brings the occurrence name and associated type in scope for each RuleClause.

  - A new relation definition which can take 2 arbitrary types
and a relation operator. The pattern matching construct also takes
a list of ruleclauses that will be generated when evaluating the
relation. This can take an arbitrary ruleclause, including the new
proposed "forall".

An example of this syntax is the following:

```
relations
    	sub: Type * Type {
    		List(asdasd) <sub! List(asds) := {
    			true.
    		},
    		RECORD(one) <sub! RECORD(other) := {
    			forall Field{d1}:ty1 in D(one) => {
    				Field{d1} -> other,
    				Field{d1} |-> d2,
    				d2 : ty2,
    				ty1 <sub? ty2.
			}.
		}
    	}
```

In this example the UNION type does not generate any constraints.
The RECORD type does which uses the forall ruleclause directly.

### Reasoning
The new syntax is flexible in two ways:
- You can generate arbitrary new constraints when evaluating a relation, this is not limited to a specific subset
- The forall can also be used for other usecases, making it generic enough.

There is one note we have to make: since forall needs more constraints, it introduces nesting in the language. For nesting to parse nicely, we introduced brackets to actually know when the forall statements was finished.

However, as we also set that it is a list of constraints, it requires the regular separation by `,` and should end with a `.`. This might be a bit confusing, we are not sure how to address this properly. We tried different combinations with no brackets, just dots, etc.. but it would not be non-ambigous nor readable. This syntax was the best for both worlds in our opinion