### PR TITLE
Pretty scope graph dot

### DIFF
--- a/nabl2.runtime/trans/nabl2/runtime/analysis/dot.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/dot.str
@@ -9,6 +9,8 @@ rules
 
 scope-graph-to-dot: ScopeGraph(entries) ->
 $[digraph scope_graph {
+  layout=sfdp;
+  overlap=scale;
   rankdir="BT";
   [scopes]
 }] with scopes := <map(scope-to-dot);lines> entries

--- a/nabl2.runtime/trans/nabl2/runtime/editor/menus.str
+++ b/nabl2.runtime/trans/nabl2/runtime/editor/menus.str
@@ -18,7 +18,7 @@ rules
     nabl2--debug-file-result(nabl2--debug-scope-graph|"scope-graph")
 
   nabl2--debug-file-scope-graph-dot =
-    nabl2--debug-file-result(nabl2--debug-scope-graph,scope-graph-to-dot|"scope-graph.gv")
+    nabl2--debug-file-result(nabl2--debug-scope-graph,scope-graph-to-dot|"scope-graph.dot")
 
   nabl2--debug-file-name-resolution =
     nabl2--debug-file-result(nabl2--debug-name-resolution|"name-resolution")
@@ -49,7 +49,7 @@ rules
     nabl2--debug-project-result(nabl2--debug-scope-graph|"scope-graph")
 
   nabl2--debug-project-scope-graph-dot =
-    nabl2--debug-project-result(nabl2--debug-scope-graph,scope-graph-to-dot|"scope-graph.gv")
+    nabl2--debug-project-result(nabl2--debug-scope-graph,scope-graph-to-dot|"scope-graph.dot")
 
   nabl2--debug-project-name-resolution =
     nabl2--debug-project-result(nabl2--debug-name-resolution|"name-resolution")


### PR DESCRIPTION
Render dot file with sfdp using the overlap=scale algorithm.
The images generated from these dot files are much more readable.

Use the .dot extension for graph files, so graphviz recognizes them automatically in eclipse.