### PR TITLE
Improve query performance

### DIFF
--- a/statix.solver/src/main/java/mb/statix/scopegraph/reference/FastNameResolution.java
+++ b/statix.solver/src/main/java/mb/statix/scopegraph/reference/FastNameResolution.java
@@ -69,7 +69,7 @@ public class FastNameResolution<V, L, R> implements INameResolution<V, L, R> {
         for(L l : max_L) {
             final Set.Immutable<IResolutionPath<V, L, R>> env1 = env_L(smaller(L, l), re, path, specifics);
             env.__insertAll(env1);
-            if(!dataEquiv.alwaysTrue() || env1.isEmpty()) {
+            if(env1.isEmpty() || !dataEquiv.alwaysTrue()) {
                 final Set.Immutable<IResolutionPath<V, L, R>> env2 =
                         env_l(l, re, path, Set.Immutable.union(specifics, env1));
                 env.__insertAll(env2);

--- a/statix.solver/src/main/java/mb/statix/solver/query/ConstraintDataLeq.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/ConstraintDataLeq.java
@@ -28,6 +28,7 @@ public class ConstraintDataLeq implements DataLeq<ITerm> {
     private final State state;
     private final Completeness completeness;
     private final IDebugContext debug;
+    private volatile Boolean alwaysTrue;
 
     public ConstraintDataLeq(Rule constraint, State state, Completeness completeness, IDebugContext debug) {
         this.constraint = constraint;
@@ -63,7 +64,9 @@ public class ConstraintDataLeq implements DataLeq<ITerm> {
     }
 
     @Override public boolean alwaysTrue() throws InterruptedException {
-        return constraint.isAlways(state.spec()).orElse(false);
+        if (alwaysTrue != null) return alwaysTrue.booleanValue();
+        
+        return alwaysTrue = constraint.isAlways(state.spec()).orElse(false);
     }
 
 }


### PR DESCRIPTION
* Reorder checks to ensure that the simplest check occurs first, such that the more expensive check might be skipped.
* Cache the result of the relatively costly `isAlways` calculation on the rule of queries.