### PR TITLE
Move rule logic to RuleSet class

### DIFF
--- a/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
+++ b/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
@@ -7,16 +7,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.*;
+import mb.statix.spec.*;
 import org.apache.commons.math3.distribution.EnumeratedDistribution;
 import org.apache.commons.math3.util.Pair;
 import org.metaborg.util.functions.Function2;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
 
 import io.usethesource.capsule.Map;
 import io.usethesource.capsule.Set;
@@ -36,22 +34,19 @@ import mb.statix.solver.Delay;
 import mb.statix.solver.IConstraint;
 import mb.statix.solver.IState;
 import mb.statix.solver.completeness.ICompleteness;
-import mb.statix.spec.ApplyResult;
-import mb.statix.spec.Rule;
-import mb.statix.spec.RuleUtil;
-import mb.statix.spec.Spec;
+
 
 final class Expand extends SearchStrategy<FocusedSearchState<CUser>, SearchState> {
 
     private final Mode mode;
     private final Function2<Rule, Long, Double> ruleWeight;
-    private final SetMultimap<String, Rule> rules;
+    private final RuleSet rules;
 
     Expand(Spec spec, Mode mode, Function2<Rule, Long, Double> ruleWeight) {
-        this(spec, mode, ruleWeight, RuleUtil.makeUnordered(spec.rules()));
+        this(spec, mode, ruleWeight, spec.rules());
     }
 
-    Expand(Spec spec, Mode mode, Function2<Rule, Long, Double> ruleWeight, SetMultimap<String, Rule> rules) {
+    Expand(Spec spec, Mode mode, Function2<Rule, Long, Double> ruleWeight, RuleSet rules) {
         super(spec);
         this.mode = mode;
         this.ruleWeight = ruleWeight;
@@ -114,7 +109,7 @@ final class Expand extends SearchStrategy<FocusedSearchState<CUser>, SearchState
     private java.util.Map<Rule, Double> getWeightedRules(String name) {
         try {
             return cache.get(name, () -> {
-                final java.util.Set<Rule> rs = rules.get(name);
+                final ImmutableList<Rule> rs = this.rules.getIndependentRules(name);
                 final java.util.Map<String, Long> rcs =
                         rs.stream().collect(Collectors.groupingBy(Rule::label, Collectors.counting()));
                 // ImmutableMap iterates over keys in insertion-order

--- a/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
+++ b/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
@@ -109,7 +109,7 @@ final class Expand extends SearchStrategy<FocusedSearchState<CUser>, SearchState
     private java.util.Map<Rule, Double> getWeightedRules(String name) {
         try {
             return cache.get(name, () -> {
-                final ImmutableList<Rule> rs = this.rules.getIndependentRules(name);
+                final ImmutableList<Rule> rs = this.rules.getOrderIndependentRules(name);
                 final java.util.Map<String, Long> rcs =
                         rs.stream().collect(Collectors.groupingBy(Rule::label, Collectors.counting()));
                 // ImmutableMap iterates over keys in insertion-order

--- a/statix.generator/src/main/java/mb/statix/generator/strategy/SearchStrategies.java
+++ b/statix.generator/src/main/java/mb/statix/generator/strategy/SearchStrategies.java
@@ -2,6 +2,7 @@ package mb.statix.generator.strategy;
 
 import java.util.Map;
 
+import mb.statix.spec.RuleSet;
 import org.metaborg.util.functions.Action1;
 import org.metaborg.util.functions.Function1;
 import org.metaborg.util.functions.Function2;
@@ -122,7 +123,7 @@ public final class SearchStrategies {
         return expand(mode, 1d, ImmutableMap.of());
     }
 
-    public final Expand expand(Mode mode, SetMultimap<String, Rule> rules) {
+    public final Expand expand(Mode mode, RuleSet rules) {
         return expand(mode, 1d, ImmutableMap.of(), rules);
     }
 
@@ -136,8 +137,7 @@ public final class SearchStrategies {
         });
     }
 
-    public final Expand expand(Mode mode, double defaultWeight, Map<String, Double> weights,
-            SetMultimap<String, Rule> rules) {
+    public final Expand expand(Mode mode, double defaultWeight, Map<String, Double> weights, RuleSet rules) {
         return expand(mode, (r, n) -> {
             if(weights.containsKey(r.label())) {
                 return weights.get(r.label()) / (double) n;
@@ -151,7 +151,7 @@ public final class SearchStrategies {
         return new Expand(spec, mode, ruleWeight);
     }
 
-    public final Expand expand(Mode mode, Function2<Rule, Long, Double> ruleWeight, SetMultimap<String, Rule> rules) {
+    public final Expand expand(Mode mode, Function2<Rule, Long, Double> ruleWeight, RuleSet rules) {
         return new Expand(spec, mode, ruleWeight, rules);
     }
 

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -546,7 +546,7 @@ class GreedySolver {
                 final LazyDebugContext proxyDebug = new LazyDebugContext(debug);
                 final IDebugContext debug = params.debug();
 
-                final List<Rule> rules = spec.rules().get(name);
+                final List<Rule> rules = spec.rules().getRules(name);
                 final List<Tuple2<Rule, ApplyResult>> results = RuleUtil.applyOrderedAll(state, rules, args, c);
                 if(results.isEmpty()) {
                     debug.info("No rule applies");

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/StepSolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/StepSolver.java
@@ -542,7 +542,7 @@ class StepSolver implements IConstraint.CheckedCases<Optional<StepResult>, Solve
 
         final IDebugContext debug = params.debug();
 
-        final List<Rule> rules = spec.rules().get(name);
+        final List<Rule> rules = spec.rules().getRules(name);
         final List<Tuple2<Rule, ApplyResult>> results = RuleUtil.applyOrderedAll(state, rules, args, c);
         if(results.isEmpty()) {
             debug.info("No rule applies");

--- a/statix.solver/src/main/java/mb/statix/spec/ARule.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ARule.java
@@ -162,11 +162,7 @@ public abstract class ARule {
         }
 
         public Comparator<Rule> asComparator() {
-            return new Comparator<Rule>() {
-                @Override public int compare(Rule r1, Rule r2) {
-                    return LeftRightOrder.this.compare(r1, r2).orElse(0);
-                }
-            };
+            return (r1, r2) -> LeftRightOrder.this.compare(r1, r2).orElse(0);
         }
 
     }

--- a/statix.solver/src/main/java/mb/statix/spec/ASpec.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ASpec.java
@@ -24,21 +24,7 @@ import mb.nabl2.util.Tuple2;
 @Serial.Version(value = 42L)
 public abstract class ASpec {
 
-    @Value.Parameter public abstract ListMultimap<String, Rule> rules();
-
-    public ListMultimap<String, Rule> rulesWithEquivalentPatterns() {
-        final ImmutableListMultimap.Builder<String, Rule> overlappingRules = ImmutableListMultimap.builder();
-        rules().asMap().forEach((name, rules) -> {
-            overlappingRules.putAll(name, rulesWithEquivalentPatterns(rules));
-        });
-        return overlappingRules.build();
-    }
-
-    private Collection<Rule> rulesWithEquivalentPatterns(Collection<Rule> rules) {
-        return rules.stream().filter(r1 -> rules.stream().anyMatch(
-                r2 -> !r1.equals(r2) && ARule.leftRightPatternOrdering.compare(r1, r2).map(c -> c == 0).orElse(false)))
-                .collect(ImmutableList.toImmutableList());
-    }
+    @Value.Parameter public abstract RuleSet rules();
 
     @Value.Parameter public abstract Set<ITerm> edgeLabels();
 
@@ -51,7 +37,7 @@ public abstract class ASpec {
     @Value.Parameter public abstract SetMultimap<String, Tuple2<Integer, ITerm>> scopeExtensions();
 
     public static Spec of() {
-        return Spec.of(ImmutableListMultimap.of(), ImmutableSet.of(), ImmutableSet.of(), B.EMPTY_TUPLE,
+        return Spec.of(new RuleSet(ImmutableListMultimap.of()), ImmutableSet.of(), ImmutableSet.of(), B.EMPTY_TUPLE,
                 new FiniteAlphabet<>(), ImmutableSetMultimap.of());
     }
 

--- a/statix.solver/src/main/java/mb/statix/spec/RuleSet.java
+++ b/statix.solver/src/main/java/mb/statix/spec/RuleSet.java
@@ -1,0 +1,210 @@
+package mb.statix.spec;
+
+import com.google.common.collect.*;
+import mb.nabl2.terms.ITerm;
+import mb.nabl2.terms.ITermVar;
+import mb.nabl2.terms.matching.Pattern;
+import mb.nabl2.terms.substitution.IRenaming;
+import mb.nabl2.terms.unification.OccursException;
+import mb.nabl2.terms.unification.ud.IUniDisunifier;
+import mb.nabl2.terms.unification.ud.PersistentUniDisunifier;
+import mb.nabl2.util.Tuple2;
+import mb.statix.constraints.CUser;
+import mb.statix.constraints.Constraints;
+import mb.statix.solver.IConstraint;
+import mb.statix.solver.StateUtil;
+import org.metaborg.util.functions.PartialFunction1;
+import org.metaborg.util.functions.Predicate1;
+import org.metaborg.util.functions.Predicate2;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static mb.nabl2.terms.build.TermBuild.B;
+import static mb.nabl2.terms.matching.TermPattern.P;
+
+
+/**
+ * An immutable set of rules.
+ */
+public final class RuleSet {
+
+    /** The rules, ordered from most specific o least specific guard. */
+    private final ImmutableListMultimap<String, Rule> rules;
+    /** The independent rules. If a rule name is not in this map,
+     *  an independent version of its rules has not yet been created. */
+    private final Map<String, ImmutableList<Rule>> independentRules = new HashMap<>();
+
+    /**
+     * Makes a new ruleset from the specified collection of rules.
+     *
+     * This function will ensure the rules are correctly ordered from most specific to least specific guard.
+     *
+     * @param rules the rules to put into the ruleset
+     * @return the resulting ruleset
+     */
+    public static RuleSet of(Collection<Rule> rules) {
+        final ImmutableListMultimap.Builder<String, Rule> builder = ImmutableListMultimap.<String, Rule>builder()
+                .orderValuesBy(Rule.leftRightPatternOrdering.asComparator());
+        rules.forEach(rule -> builder.put(rule.name(), rule));
+        return new RuleSet(builder.build());
+    }
+
+    /**
+     * Initializes a new instance of the {@link RuleSet} class.
+     *
+     * @param rules the multimap of rule names to rules, ordered from most specific to least specific guard
+     */
+    public RuleSet(ListMultimap<String, Rule> rules) {
+        this.rules = ImmutableListMultimap.copyOf(rules);
+    }
+
+    /**
+     * Returns a map of rule names to a list of rules.
+     *
+     * The rules are returned in order from most specific to least specific guard.
+     *
+     * @return the map of rules
+     */
+    public ImmutableListMultimap<String, Rule> getRuleMap() { return this.rules; }
+
+    /**
+     * Gets the names of all the rules in the ruleset.
+     *
+     * @return the set of rule names
+     */
+    public ImmutableSet<String> getRuleNames() {
+        return this.rules.keySet();
+    }
+
+    /**
+     * Gets all rules in the ruleset.
+     *
+     * The rules are returned in order from most specific to least specific guard.
+     *
+     * @return all rules
+     */
+    public ImmutableCollection<Rule> getAllRules() {
+        return this.rules.values();
+    }
+
+    /**
+     * Gets the rules with the specified name in the ruleset.
+     *
+     * The rules are returned in order from most specific to least specific guard.
+     *
+     * @param name the name of the rules to find
+     * @return the rules with the specified name
+     */
+    public ImmutableList<Rule> getRules(String name) {
+        return this.rules.get(name);
+    }
+
+    /**
+     * Gets a map of lists of rules, where the match order is reflected in (dis)equality constraints
+     * in the rule bodies. The resulting rules can be applied independent of the other rules in the set.
+     *
+     * Note that compared to using applyAll, mismatches may only be discovered when the body of the returned rules is
+     * evaluated, instead of during the matching process already.
+     *
+     * @return a map of a list of rules that are mutually independent
+     */
+    public ImmutableListMultimap<String, Rule> getAllIndependentRules() {
+        final ImmutableListMultimap.Builder<String, Rule> independentRules = ImmutableListMultimap.builder();
+        this.rules.keySet().forEach(name -> independentRules.putAll(name, getIndependentRules(name)));
+        return independentRules.build();
+    }
+
+    /**
+     * Gets a list of rules with the specified name, where the match order is reflected in (dis)equality constraints
+     * in the rule bodies. The resulting rules can be applied independent of the other rules in the set.
+     *
+     * Note that compared to using applyAll, mismatches may only be discovered when the body of the returned rules is
+     * evaluated, instead of during the matching process already.
+     *
+     * @param name the name of the rules to find
+     * @return a list of rules that are mutually independent
+     */
+    public ImmutableList<Rule> getIndependentRules(String name) {
+        return this.independentRules.computeIfAbsent(name, n -> computeIndependentRules(getRules(name)));
+    }
+
+    /**
+     * Computes the independent rules.
+     *
+     * @param rules the set of rules for which to compute
+     * @return the set of independent rules
+     */
+    private ImmutableList<Rule> computeIndependentRules(ImmutableList<Rule> rules) {
+        final List<Pattern> guards = Lists.newArrayList();
+
+        return rules.stream().flatMap(r -> {
+            final IUniDisunifier.Transient diseqs = PersistentUniDisunifier.Immutable.of().melt();
+
+            // Eliminate wildcards in the patterns
+            final FreshVars fresh = new FreshVars(r.varSet());
+            final List<Pattern> paramPatterns = r.params().stream().map(p -> p.eliminateWld(() -> fresh.fresh("_")))
+                    .collect(ImmutableList.toImmutableList());
+            fresh.fix();
+            final Pattern paramsPattern = P.newTuple(paramPatterns);
+
+            // Create term for params and add implied equalities
+            final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> p_eqs = paramsPattern.asTerm(Optional::get);
+            try {
+                if (!diseqs.unify(p_eqs._2()).isPresent()) {
+                    return Stream.empty();
+                }
+            } catch (OccursException e) {
+                return Stream.empty();
+            }
+
+            // Add disunifications for all patterns from previous rules
+            final boolean guardsOk = guards.stream().allMatch(g -> {
+                final IRenaming swap = fresh.fresh(g.getVars());
+                final Pattern g1 = g.eliminateWld(() -> fresh.fresh("_"));
+                final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> t_eqs = g1.apply(swap).asTerm(v -> v.get());
+                // Add internal equalities from the guard pattern, which are also reasons why the guard wouldn't match
+                final List<ITermVar> leftEqs =
+                        t_eqs._2().stream().map(Tuple2::_1).collect(ImmutableList.toImmutableList());
+                final List<ITerm> rightEqs =
+                        t_eqs._2().stream().map(Tuple2::_2).collect(ImmutableList.toImmutableList());
+                final ITerm left = B.newTuple(p_eqs._1(), B.newTuple(leftEqs));
+                final ITerm right = B.newTuple(t_eqs._1(), B.newTuple(rightEqs));
+                final Set<ITermVar> universals = fresh.reset();
+                return diseqs.disunify(universals, left, right).isPresent();
+            });
+            if (!guardsOk) return Stream.empty();
+
+            // Add params as guard for next rule
+            guards.add(paramsPattern);
+
+            final IConstraint body = Constraints.conjoin(StateUtil.asInequalities(diseqs), r.body());
+            return Stream.of(r.withParams(paramPatterns).withBody(body));
+        }).collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Gets a multimap from names to rules that have equivalent patterns.
+     *
+     * @return the map from names to equivalent rules
+     */
+    public ListMultimap<String, Rule> getAllEquivalentRules() {
+        final ImmutableListMultimap.Builder<String, Rule> overlappingRules = ImmutableListMultimap.builder();
+        this.rules.keySet().forEach(name -> overlappingRules.putAll(name, getEquivalentRules(name)));
+        return overlappingRules.build();
+    }
+
+    /**
+     * Gets a set of rules with equivalent patterns.
+     *
+     * @param name the name of the rules to find
+     * @return a set of rules with equivalent patterns
+     */
+    public ImmutableSet<Rule> getEquivalentRules(String name) {
+        ImmutableList<Rule> rules = getRules(name);
+        return rules.stream().filter(a -> rules.stream().anyMatch(b -> !a.equals(b) && ARule.leftRightPatternOrdering.compare(a, b).map(c -> c == 0).orElse(false)))
+                .collect(ImmutableSet.toImmutableSet());
+    }
+
+}

--- a/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
+++ b/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
@@ -210,73 +210,6 @@ public class RuleUtil {
     }
 
     /**
-     * Convert an ordered list of rules to a set of rules where the match order is reflected in (dis)equality
-     * constraints in the rule bodies. The resulting rules can be applied independent of the other rules in the set.
-     * Note that compared to using applyAll, mismatches may only be discovered when the body of the returned rules is
-     * evaluated, instead of during the matching process already.
-     * 
-     * @param rules
-     *            An ordered list of rules
-     * 
-     * @return A set of rules that are mutually independent
-     */
-    public static final java.util.Set<Rule> makeUnordered(Collection<Rule> rules) {
-        final List<Pattern> guards = Lists.newArrayList();
-        // go thorugh all rules in sequence
-        return rules.stream().<Rule>flatMap(r -> {
-            final IUniDisunifier.Transient diseqs = PersistentUniDisunifier.Immutable.of().melt();
-
-            // eliminate wildcards in the patterns
-            final FreshVars fresh = new FreshVars(r.varSet());
-            final List<Pattern> paramPatterns = r.params().stream().map(p -> p.eliminateWld(() -> fresh.fresh("_")))
-                    .collect(ImmutableList.toImmutableList());
-            fresh.fix();
-            final Pattern paramsPattern = P.newTuple(paramPatterns);
-
-            // create term for params and add implied equalities
-            final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> p_eqs = paramsPattern.asTerm(v -> v.get());
-            try {
-                if(!diseqs.unify(p_eqs._2()).isPresent()) {
-                    return Stream.empty();
-                }
-            } catch(OccursException e) {
-                return Stream.empty();
-            }
-
-            // add disunifications for all patterns from previous rules
-            final boolean guardsOk = guards.stream().allMatch(g -> {
-                final IRenaming swap = fresh.fresh(g.getVars());
-                final Pattern g1 = g.eliminateWld(() -> fresh.fresh("_"));
-                final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> t_eqs = g1.apply(swap).asTerm(v -> v.get());
-                // add internal equalities from the guard pattern, which are also reasons why the guard wouldn't match
-                final List<ITermVar> leftEqs =
-                        t_eqs._2().stream().map(Tuple2::_1).collect(ImmutableList.toImmutableList());
-                final List<ITerm> rightEqs =
-                        t_eqs._2().stream().map(Tuple2::_2).collect(ImmutableList.toImmutableList());
-                final ITerm left = B.newTuple(p_eqs._1(), B.newTuple(leftEqs));
-                final ITerm right = B.newTuple(t_eqs._1(), B.newTuple(rightEqs));
-                final java.util.Set<ITermVar> universals = fresh.reset();
-                return diseqs.disunify(universals, left, right).isPresent();
-            });
-            if(!guardsOk) {
-                return Stream.empty();
-            }
-
-            // add params as guard for next rule
-            guards.add(paramsPattern);
-
-            final IConstraint body = Constraints.conjoin(StateUtil.asInequalities(diseqs), r.body());
-            return Stream.of(r.withParams(paramPatterns).withBody(body));
-        }).collect(ImmutableSet.toImmutableSet());
-    }
-
-    public static final SetMultimap<String, Rule> makeUnordered(ListMultimap<String, Rule> rules) {
-        final ImmutableSetMultimap.Builder<String, Rule> newRules = ImmutableSetMultimap.builder();
-        rules.asMap().forEach((name, rs) -> newRules.putAll(name, makeUnordered(rs)));
-        return newRules.build();
-    }
-
-    /**
      * Inline rule into the i-th matching premise of the second rule. Inlining always succeeds (use simplify to solve
      * equalities in the resulting rule). The function returns empty if nothing was inlined because no i-th matching
      * premise existed.
@@ -372,38 +305,38 @@ public class RuleUtil {
      * includeRule determine which premises should be inlined. The fragments are closed only w.r.t. the included
      * predicates.
      */
-    public static final SetMultimap<String, Rule> makeFragments(ListMultimap<String, Rule> orderedRules,
+    public static final SetMultimap<String, Rule> makeFragments(RuleSet rules,
             Predicate1<String> includePredicate, Predicate2<String, String> includeRule, int generations) {
         final SetMultimap<String, Rule> fragments = HashMultimap.create();
 
         // 1. make all rules unordered, and keep included rules
-        final SetMultimap<String, Rule> rules = HashMultimap.create();
-        for(Map.Entry<String, Collection<Rule>> e : orderedRules.asMap().entrySet()) {
-            if(includePredicate.test(e.getKey())) {
-                for(Rule r : makeUnordered(e.getValue())) {
+        final SetMultimap<String, Rule> newRules = HashMultimap.create();
+        for (String ruleName : rules.getRuleNames()) {
+            if(includePredicate.test(ruleName)) {
+                for (Rule r : rules.getIndependentRules(ruleName)) {
                     if(includeRule.test(r.name(), r.label())) {
-                        rules.put(e.getKey(), r);
+                        newRules.put(ruleName, r);
                     }
                 }
             }
         }
 
         final PartialFunction1<IConstraint, CUser> expandable =
-                c -> (c instanceof CUser && rules.containsKey(((CUser) c).name())) ? Optional.of(((CUser) c))
+                c -> (c instanceof CUser && newRules.containsKey(((CUser) c).name())) ? Optional.of(((CUser) c))
                         : Optional.empty();
 
         // 2. find the included axioms and move to fragments
-        for(Map.Entry<String, Rule> e : rules.entries()) {
+        for(Map.Entry<String, Rule> e : newRules.entries()) {
             if(Constraints.collectBase(expandable, false).apply(e.getValue().body()).isEmpty()) {
                 fragments.put(e.getKey(), e.getValue());
             }
         }
-        fragments.forEach(rules::remove);
+        fragments.forEach(newRules::remove);
 
         // 3. for each generation, inline fragments into rules
         for(int g = 0; g < generations; g++) {
             final SetMultimap<String, Rule> generation = HashMultimap.create();
-            for(Map.Entry<String, Rule> e : rules.entries()) {
+            for(Map.Entry<String, Rule> e : newRules.entries()) {
                 final String name = e.getKey();
                 final Rule r = e.getValue();
                 final FreshVars fresh = new FreshVars(r.varSet());

--- a/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
+++ b/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
@@ -89,7 +89,7 @@ public abstract class StatixPrimitive extends AbstractPrimitive {
     ///////////////////////////////////////
 
     protected void reportOverlappingRules(final Spec spec) {
-        final ListMultimap<String, Rule> rulesWithEquivalentPatterns = spec.rulesWithEquivalentPatterns();
+        final ListMultimap<String, Rule> rulesWithEquivalentPatterns = spec.rules().getAllEquivalentRules();
         if(!rulesWithEquivalentPatterns.isEmpty()) {
             logger.error("+--------------------------------------+");
             logger.error("| FOUND RULES WITH EQUIVALENT PATTERNS |");

--- a/statix.solver/src/main/java/mb/statix/spoofax/StatixTerms.java
+++ b/statix.solver/src/main/java/mb/statix/spoofax/StatixTerms.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import mb.statix.spec.RuleSet;
 import org.metaborg.util.Ref;
 import org.metaborg.util.iterators.Iterables2;
 import org.metaborg.util.log.ILogger;
@@ -16,11 +17,9 @@ import org.metaborg.util.log.LoggerUtils;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
@@ -99,15 +98,8 @@ public class StatixTerms {
                 });
     }
 
-    public static IMatcher<ListMultimap<String, Rule>> rules() {
-        return M.listElems(M.req(rule())).map(rules -> {
-            final ImmutableListMultimap.Builder<String, Rule> builder = ImmutableListMultimap.<String, Rule>builder()
-                    .orderValuesBy(Rule.leftRightPatternOrdering.asComparator());
-            rules.stream().forEach(rule -> {
-                builder.put(rule.name(), rule);
-            });
-            return builder.build();
-        });
+    public static IMatcher<RuleSet> rules() {
+        return M.listElems(M.req(rule())).map(RuleSet::of);
     }
 
     public static IMatcher<Rule> rule() {

--- a/statix.solver/src/test/java/mb/statix/spec/RuleUtilTest.java
+++ b/statix.solver/src/test/java/mb/statix/spec/RuleUtilTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableCollection;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 
@@ -60,6 +61,7 @@ public class RuleUtilTest {
           Rule.of("c", Arrays.asList(p1, P.newAs(v1, P.newInt(1))), body)
         , Rule.of("c", Arrays.asList(p1, p2), body)
         );
+        // @formatter:on
         testUnorderedRules(rules);
     }
 
@@ -67,8 +69,7 @@ public class RuleUtilTest {
         logger.info("Ordered rules:");
         rules.forEach(r -> logger.info(" * {}", r));
 
-        // @formatter:on
-        final Set<Rule> newRules = RuleUtil.makeUnordered(rules);
+        ImmutableCollection<Rule> newRules = RuleSet.of(rules).getAllIndependentRules().values();
         logger.info("Unordered rules:");
         newRules.forEach(r -> logger.info(" * {}", r));
     }

--- a/statix.solver/src/test/java/mb/statix/spec/RuleUtilTest.java
+++ b/statix.solver/src/test/java/mb/statix/spec/RuleUtilTest.java
@@ -6,7 +6,6 @@ import static mb.nabl2.terms.matching.TermPattern.P;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import com.google.common.collect.ImmutableCollection;
 import org.metaborg.util.log.ILogger;
@@ -69,7 +68,7 @@ public class RuleUtilTest {
         logger.info("Ordered rules:");
         rules.forEach(r -> logger.info(" * {}", r));
 
-        ImmutableCollection<Rule> newRules = RuleSet.of(rules).getAllIndependentRules().values();
+        ImmutableCollection<Rule> newRules = RuleSet.of(rules).getAllOrderIndependentRules().values();
         logger.info("Unordered rules:");
         newRules.forEach(r -> logger.info(" * {}", r));
     }


### PR DESCRIPTION
Moved rule-related logic that was present across classes and in the RuleUtil class into a single class RuleSet.