### PR TITLE
Use baseline version of SDF3 and ESV (which depends on SDF3).

### DIFF
--- a/statix.lang/metaborg.yaml
+++ b/statix.lang/metaborg.yaml
@@ -1,10 +1,11 @@
 ---
 id: org.metaborg:statix.lang:${metaborgVersion}
 name: StatixLang
+metaborgBaselineVersion: 2.3.0
 dependencies:
   compile:
-  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
-  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgBaselineVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgBaselineVersion}
   - org.metaborg:org.metaborg.meta.nabl2.lang:${metaborgVersion}
   source:
   - org.metaborg:meta.lib.spoofax:${metaborgVersion}

--- a/statix.runtime/metaborg.yaml
+++ b/statix.runtime/metaborg.yaml
@@ -1,10 +1,11 @@
 ---
 id: org.metaborg:statix.runtime:${metaborgVersion}
 name: StatixRuntime
+metaborgBaselineVersion: 2.3.0
 dependencies:
   compile:
-  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgVersion}
-  - org.metaborg:org.metaborg.meta.lang.template:${metaborgVersion}
+  - org.metaborg:org.metaborg.meta.lang.esv:${metaborgBaselineVersion}
+  - org.metaborg:org.metaborg.meta.lang.template:${metaborgBaselineVersion}
   source:
   - org.metaborg:meta.lib.spoofax:${metaborgVersion}
 exports:


### PR DESCRIPTION
Use baseline version of SDF3 and ESV (which depends on SDF3) in preparation of using Statix in SDF3. Tested with a local build of spoofax-releng.