### PR TITLE
Add a default implementation for `stx-editor-hover`

### DIFF
--- a/statix.runtime/trans/statix/api.str
+++ b/statix.runtime/trans/statix/api.str
@@ -84,7 +84,9 @@ rules // services
 
   /** Default hover strategy
    */
-  stx-editor-hover = stx--editor-hover
+  stx-editor-hover = stx--editor-hover(strip-annos; write-to-string | "type")
+  stx-editor-hover(|prop) = stx--editor-hover(strip-annos; write-to-string | prop)
+  stx-editor-hover(pp | prop) = stx--editor-hover(pp | prop)
 
 rules // prettyprinting
 

--- a/statix.runtime/trans/statix/runtime/services.str
+++ b/statix.runtime/trans/statix/runtime/services.str
@@ -16,10 +16,12 @@ rules
     ; a := <stx--get-ast-analysis> node
     ; r := <stx--get-ast-property(|a,Ref())> node
 
-  stx--editor-hover:
-      (node, position, ast, path, project-path) -> lbl
+strategies
+
+  stx--editor-hover(pp | prop):
+      (node, position, ast, path, project-path) -> label
     where
-      a  := <stx-get-ast-analysis> node
-    ; ty := <stx-get-ast-property(|a,"type")> node
+      a       := <stx-get-ast-analysis> node
+    ; propval := <stx-get-ast-property(|a, prop)> node
     with
-      lbl := <strip-annos; write-to-string> ty
+      label := <pp> propval

--- a/statix.runtime/trans/statix/runtime/services.str
+++ b/statix.runtime/trans/statix/runtime/services.str
@@ -17,4 +17,9 @@ rules
     ; r := <stx--get-ast-property(|a,Ref())> node
 
   stx--editor-hover:
-      (node, position, ast, path, project-path) -> <fail>
+      (node, position, ast, path, project-path) -> lbl
+    where
+      a  := <stx-get-ast-analysis> node
+    ; ty := <stx-get-ast-property(|a,"type")> node
+    with
+      lbl := <strip-annos; write-to-string> ty


### PR DESCRIPTION
The default implementation of `stx-editor-hover` is `stx--editor-hover`, which defaults to the `fail` strategy. This change provides a default implementation, displaying the node's type information instead. The implementation was adapted from [Statix's implementation in NaBL2](https://github.com/metaborg/nabl/blob/cfcb0770f2af3f234481a624507acecc063fad8f/statix.integrationtest/lang.fgj/trans/analysis.str#L34-L40).

Screenshot:

![image](https://user-images.githubusercontent.com/17430732/82556275-b3490580-9b69-11ea-976c-d081d3a9c019.png)

**To note**

This strategy does not employ the `pp-TYPE` strategy that Statix uses for its own hover information, and I'm not sure what exactly it's doing. The screenshot above demonstrates what it looks like.