### PR TITLE
Implement equals/hashcode on Rule and subfields

### DIFF
--- a/nabl2.solver/src/main/java/mb/nabl2/relations/variants/VariantRelation.java
+++ b/nabl2.solver/src/main/java/mb/nabl2/relations/variants/VariantRelation.java
@@ -210,6 +210,18 @@ public abstract class VariantRelation<T> implements IVariantRelation<T> {
                     Relation.Transient.of(description.relationDescription()));
         }
 
+        @Override public boolean equals(Object o) {
+            if(this == o) return true;
+            if(o == null || getClass() != o.getClass()) return false;
+            VariantRelation.Transient<?> that = (VariantRelation.Transient<?>)o;
+            return Objects.equals(description, that.description) &&
+                Objects.equals(baseRelation, that.baseRelation);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(description, baseRelation);
+        }
     }
 
 }

--- a/nabl2.solver/src/main/java/mb/nabl2/relations/variants/VariantRelation.java
+++ b/nabl2.solver/src/main/java/mb/nabl2/relations/variants/VariantRelation.java
@@ -1,6 +1,7 @@
 package mb.nabl2.relations.variants;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -153,6 +154,19 @@ public abstract class VariantRelation<T> implements IVariantRelation<T> {
                     Relation.Immutable.of(description.relationDescription()));
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            VariantRelation.Immutable<?> immutable = (VariantRelation.Immutable<?>) o;
+            return Objects.equals(description, immutable.description) &&
+                    Objects.equals(baseRelation, immutable.baseRelation);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(description, baseRelation);
+        }
     }
 
 

--- a/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -136,4 +137,20 @@ public class RegExpMatcher<S> implements IRegExpMatcher<S>, Serializable {
         return new RegExpMatcher<>(initial, stateTransitions, defaultTransitions, nonFinal, isNullable);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RegExpMatcher<?> that = (RegExpMatcher<?>) o;
+        return Objects.equals(state, that.state) &&
+                Objects.equals(stateTransitions, that.stateTransitions) &&
+                Objects.equals(defaultTransitions, that.defaultTransitions) &&
+                Objects.equals(nonFinal, that.nonFinal) &&
+                Objects.equals(isNullable, that.isNullable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(state, stateTransitions, defaultTransitions, nonFinal, isNullable);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
@@ -142,15 +142,11 @@ public class RegExpMatcher<S> implements IRegExpMatcher<S>, Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RegExpMatcher<?> that = (RegExpMatcher<?>) o;
-        return Objects.equals(state, that.state) &&
-                Objects.equals(stateTransitions, that.stateTransitions) &&
-                Objects.equals(defaultTransitions, that.defaultTransitions) &&
-                Objects.equals(nonFinal, that.nonFinal) &&
-                Objects.equals(isNullable, that.isNullable);
+        return Objects.equals(state, that.state);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, stateTransitions, defaultTransitions, nonFinal, isNullable);
+        return Objects.hash(state);
     }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
@@ -139,9 +139,9 @@ public class RegExpMatcher<S> implements IRegExpMatcher<S>, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RegExpMatcher<?> that = (RegExpMatcher<?>) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        RegExpMatcher<?> that = (RegExpMatcher<?>)o;
         return Objects.equals(state, that.state);
     }
 

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ApplPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ApplPattern.java
@@ -3,6 +3,7 @@ package mb.nabl2.terms.matching;
 import static mb.nabl2.terms.build.TermBuild.B;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -92,4 +93,17 @@ class ApplPattern extends Pattern {
         return sb.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApplPattern that = (ApplPattern) o;
+        return Objects.equals(op, that.op) &&
+                Objects.equals(args, that.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, args);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ApplPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ApplPattern.java
@@ -95,11 +95,11 @@ class ApplPattern extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ApplPattern that = (ApplPattern) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        ApplPattern that = (ApplPattern)o;
         return Objects.equals(op, that.op) &&
-                Objects.equals(args, that.args);
+            Objects.equals(args, that.args);
     }
 
     @Override

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
@@ -3,6 +3,7 @@ package mb.nabl2.terms.matching;
 import static mb.nabl2.terms.build.TermBuild.B;
 import static mb.nabl2.terms.matching.TermMatch.M;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -83,4 +84,17 @@ class ConsPattern extends Pattern {
         return "[" + head.toString() + "|" + tail.toString() + "]";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConsPattern that = (ConsPattern) o;
+        return Objects.equals(head, that.head) &&
+                Objects.equals(tail, that.tail);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(head, tail);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
@@ -70,7 +70,7 @@ class ConsPattern extends Pattern {
     @Override public ConsPattern apply(IRenaming subst) {
         return new ConsPattern(head.apply(subst), tail.apply(subst), getAttachments());
     }
-    
+
     @Override public ConsPattern eliminateWld(Function0<ITermVar> fresh) {
         return new ConsPattern(head.eliminateWld(fresh), tail.eliminateWld(fresh), getAttachments());
     }
@@ -86,11 +86,11 @@ class ConsPattern extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
         ConsPattern that = (ConsPattern) o;
         return Objects.equals(head, that.head) &&
-                Objects.equals(tail, that.tail);
+            Objects.equals(tail, that.tail);
     }
 
     @Override

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
@@ -72,9 +72,9 @@ class IntPattern extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        IntPattern that = (IntPattern) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        IntPattern that = (IntPattern)o;
         return value == that.value;
     }
 

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
@@ -2,6 +2,7 @@ package mb.nabl2.terms.matching;
 
 import static mb.nabl2.terms.build.TermBuild.B;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -69,4 +70,16 @@ class IntPattern extends Pattern {
         return Integer.toString(value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IntPattern that = (IntPattern) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
@@ -67,7 +67,7 @@ class NilPattern extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
+        if(this == o) return true;
         return o != null && getClass() == o.getClass();
     }
 

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
@@ -65,4 +65,14 @@ class NilPattern extends Pattern {
         return "[]";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return NilPattern.class.hashCode();
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternAs.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternAs.java
@@ -1,5 +1,6 @@
 package mb.nabl2.terms.matching;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -88,4 +89,17 @@ class PatternAs extends Pattern {
         return var.toString() + "@" + pattern.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PatternAs patternAs = (PatternAs) o;
+        return Objects.equals(var, patternAs.var) &&
+                Objects.equals(pattern, patternAs.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(var, pattern);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternAs.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternAs.java
@@ -91,11 +91,11 @@ class PatternAs extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PatternAs patternAs = (PatternAs) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        PatternAs patternAs = (PatternAs)o;
         return Objects.equals(var, patternAs.var) &&
-                Objects.equals(pattern, patternAs.pattern);
+            Objects.equals(pattern, patternAs.pattern);
     }
 
     @Override

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternVar.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternVar.java
@@ -1,5 +1,6 @@
 package mb.nabl2.terms.matching;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -86,4 +87,16 @@ class PatternVar extends Pattern {
         return isWildcard() ? "_" : var.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PatternVar that = (PatternVar) o;
+        return Objects.equals(var, that.var);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(var);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternVar.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/PatternVar.java
@@ -89,9 +89,9 @@ class PatternVar extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PatternVar that = (PatternVar) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        PatternVar that = (PatternVar)o;
         return Objects.equals(var, that.var);
     }
 

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
@@ -2,6 +2,7 @@ package mb.nabl2.terms.matching;
 
 import static mb.nabl2.terms.build.TermBuild.B;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -69,4 +70,16 @@ class StringPattern extends Pattern {
         return "\"" + value + "\"";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StringPattern that = (StringPattern) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
@@ -72,9 +72,9 @@ class StringPattern extends Pattern {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        StringPattern that = (StringPattern) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        StringPattern that = (StringPattern)o;
         return Objects.equals(value, that.value);
     }
 

--- a/statix.solver/src/main/java/mb/statix/arithmetic/ArithTest.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/ArithTest.java
@@ -30,12 +30,12 @@ public class ArithTest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArithTest arithTest = (ArithTest) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        ArithTest arithTest = (ArithTest)o;
         return isEquals == arithTest.isEquals &&
-                Objects.equals(op, arithTest.op) &&
-                Objects.equals(f, arithTest.f);
+            Objects.equals(op, arithTest.op) &&
+            Objects.equals(f, arithTest.f);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/arithmetic/ArithTest.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/ArithTest.java
@@ -2,6 +2,8 @@ package mb.statix.arithmetic;
 
 import org.metaborg.util.functions.Predicate2;
 
+import java.util.Objects;
+
 public class ArithTest {
 
     private final String op;
@@ -26,4 +28,18 @@ public class ArithTest {
         return op;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArithTest arithTest = (ArithTest) o;
+        return isEquals == arithTest.isEquals &&
+                Objects.equals(op, arithTest.op) &&
+                Objects.equals(f, arithTest.f);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, f, isEquals);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/arithmetic/BinExpr.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/BinExpr.java
@@ -9,6 +9,8 @@ import mb.nabl2.terms.unification.ud.IUniDisunifier;
 import mb.nabl2.util.TermFormatter;
 import mb.statix.solver.Delay;
 
+import java.util.Objects;
+
 class BinExpr implements ArithExpr {
 
     private final String op;
@@ -43,4 +45,19 @@ class BinExpr implements ArithExpr {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BinExpr binExpr = (BinExpr) o;
+        return Objects.equals(op, binExpr.op) &&
+                Objects.equals(ae1, binExpr.ae1) &&
+                Objects.equals(ae2, binExpr.ae2) &&
+                Objects.equals(f, binExpr.f);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, ae1, ae2, f);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/arithmetic/BinExpr.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/BinExpr.java
@@ -47,13 +47,13 @@ class BinExpr implements ArithExpr {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BinExpr binExpr = (BinExpr) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        BinExpr binExpr = (BinExpr)o;
         return Objects.equals(op, binExpr.op) &&
-                Objects.equals(ae1, binExpr.ae1) &&
-                Objects.equals(ae2, binExpr.ae2) &&
-                Objects.equals(f, binExpr.f);
+            Objects.equals(ae1, binExpr.ae1) &&
+            Objects.equals(ae2, binExpr.ae2) &&
+            Objects.equals(f, binExpr.f);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/arithmetic/TermExpr.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/TermExpr.java
@@ -52,9 +52,9 @@ class TermExpr implements ArithExpr {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TermExpr termExpr = (TermExpr) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        TermExpr termExpr = (TermExpr)o;
         return Objects.equals(term, termExpr.term);
     }
 

--- a/statix.solver/src/main/java/mb/statix/arithmetic/TermExpr.java
+++ b/statix.solver/src/main/java/mb/statix/arithmetic/TermExpr.java
@@ -2,6 +2,7 @@ package mb.statix.arithmetic;
 
 import static mb.nabl2.terms.matching.TermMatch.M;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import com.google.common.collect.Multiset;
@@ -49,5 +50,16 @@ class TermExpr implements ArithExpr {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermExpr termExpr = (TermExpr) o;
+        return Objects.equals(term, termExpr.term);
+    }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(term);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -110,14 +110,14 @@ public class CArith implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CArith cArith = (CArith) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CArith cArith = (CArith)o;
         return Objects.equals(expr1, cArith.expr1) &&
-                Objects.equals(op, cArith.op) &&
-                Objects.equals(expr2, cArith.expr2) &&
-                Objects.equals(cause, cArith.cause) &&
-                Objects.equals(message, cArith.message);
+            Objects.equals(op, cArith.op) &&
+            Objects.equals(expr2, cArith.expr2) &&
+            Objects.equals(cause, cArith.cause) &&
+            Objects.equals(message, cArith.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -107,4 +108,20 @@ public class CArith implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CArith cArith = (CArith) o;
+        return Objects.equals(expr1, cArith.expr1) &&
+                Objects.equals(op, cArith.op) &&
+                Objects.equals(expr2, cArith.expr2) &&
+                Objects.equals(cause, cArith.cause) &&
+                Objects.equals(message, cArith.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expr1, op, expr2, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -88,12 +88,12 @@ public class CAstId implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CAstId cAstId = (CAstId) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CAstId cAstId = (CAstId)o;
         return Objects.equals(term, cAstId.term) &&
-                Objects.equals(idTerm, cAstId.idTerm) &&
-                Objects.equals(cause, cAstId.cause);
+            Objects.equals(idTerm, cAstId.idTerm) &&
+            Objects.equals(cause, cAstId.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -85,4 +86,18 @@ public class CAstId implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CAstId cAstId = (CAstId) o;
+        return Objects.equals(term, cAstId.term) &&
+                Objects.equals(idTerm, cAstId.idTerm) &&
+                Objects.equals(cause, cAstId.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(term, idTerm, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -114,14 +114,14 @@ public class CAstProperty implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CAstProperty that = (CAstProperty) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CAstProperty that = (CAstProperty)o;
         return Objects.equals(idTerm, that.idTerm) &&
-                Objects.equals(property, that.property) &&
-                op == that.op &&
-                Objects.equals(value, that.value) &&
-                Objects.equals(cause, that.cause);
+            Objects.equals(property, that.property) &&
+            op == that.op &&
+            Objects.equals(value, that.value) &&
+            Objects.equals(cause, that.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -111,4 +112,20 @@ public class CAstProperty implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CAstProperty that = (CAstProperty) o;
+        return Objects.equals(idTerm, that.idTerm) &&
+                Objects.equals(property, that.property) &&
+                op == that.op &&
+                Objects.equals(value, that.value) &&
+                Objects.equals(cause, that.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idTerm, property, op, value, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -83,4 +84,18 @@ public class CConj implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CConj cConj = (CConj) o;
+        return Objects.equals(left, cConj.left) &&
+                Objects.equals(right, cConj.right) &&
+                Objects.equals(cause, cConj.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -86,12 +86,12 @@ public class CConj implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CConj cConj = (CConj) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CConj cConj = (CConj)o;
         return Objects.equals(left, cConj.left) &&
-                Objects.equals(right, cConj.right) &&
-                Objects.equals(cause, cConj.cause);
+            Objects.equals(right, cConj.right) &&
+            Objects.equals(cause, cConj.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -105,13 +105,13 @@ public class CEqual implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CEqual cEqual = (CEqual) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CEqual cEqual = (CEqual)o;
         return Objects.equals(term1, cEqual.term1) &&
-                Objects.equals(term2, cEqual.term2) &&
-                Objects.equals(cause, cEqual.cause) &&
-                Objects.equals(message, cEqual.message);
+            Objects.equals(term2, cEqual.term2) &&
+            Objects.equals(cause, cEqual.cause) &&
+            Objects.equals(message, cEqual.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -102,4 +103,19 @@ public class CEqual implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CEqual cEqual = (CEqual) o;
+        return Objects.equals(term1, cEqual.term1) &&
+                Objects.equals(term2, cEqual.term2) &&
+                Objects.equals(cause, cEqual.cause) &&
+                Objects.equals(message, cEqual.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(term1, term2, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -88,12 +88,12 @@ public class CExists implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CExists cExists = (CExists) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CExists cExists = (CExists)o;
         return Objects.equals(vars, cExists.vars) &&
-                Objects.equals(constraint, cExists.constraint) &&
-                Objects.equals(cause, cExists.cause);
+            Objects.equals(constraint, cExists.constraint) &&
+            Objects.equals(cause, cExists.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -85,4 +86,18 @@ public class CExists implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CExists cExists = (CExists) o;
+        return Objects.equals(vars, cExists.vars) &&
+                Objects.equals(constraint, cExists.constraint) &&
+                Objects.equals(cause, cExists.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vars, constraint, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -81,11 +81,11 @@ public class CFalse implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CFalse cFalse = (CFalse) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CFalse cFalse = (CFalse)o;
         return Objects.equals(cause, cFalse.cause) &&
-                Objects.equals(message, cFalse.message);
+            Objects.equals(message, cFalse.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -78,4 +79,17 @@ public class CFalse implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CFalse cFalse = (CFalse) o;
+        return Objects.equals(cause, cFalse.cause) &&
+                Objects.equals(message, cFalse.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -125,14 +125,14 @@ public class CInequal implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CInequal cInequal = (CInequal) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CInequal cInequal = (CInequal)o;
         return Objects.equals(universals, cInequal.universals) &&
-                Objects.equals(term1, cInequal.term1) &&
-                Objects.equals(term2, cInequal.term2) &&
-                Objects.equals(cause, cInequal.cause) &&
-                Objects.equals(message, cInequal.message);
+            Objects.equals(term1, cInequal.term1) &&
+            Objects.equals(term2, cInequal.term2) &&
+            Objects.equals(cause, cInequal.cause) &&
+            Objects.equals(message, cInequal.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -122,4 +123,20 @@ public class CInequal implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CInequal cInequal = (CInequal) o;
+        return Objects.equals(universals, cInequal.universals) &&
+                Objects.equals(term1, cInequal.term1) &&
+                Objects.equals(term2, cInequal.term2) &&
+                Objects.equals(cause, cInequal.cause) &&
+                Objects.equals(message, cInequal.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(universals, term1, term2, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -2,6 +2,7 @@ package mb.statix.constraints;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -80,4 +81,17 @@ public class CNew implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CNew cNew = (CNew) o;
+        return Objects.equals(terms, cNew.terms) &&
+                Objects.equals(cause, cNew.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(terms, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -83,11 +83,11 @@ public class CNew implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CNew cNew = (CNew) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CNew cNew = (CNew)o;
         return Objects.equals(terms, cNew.terms) &&
-                Objects.equals(cause, cNew.cause);
+            Objects.equals(cause, cNew.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -131,4 +132,22 @@ public class CResolveQuery implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CResolveQuery that = (CResolveQuery) o;
+        return Objects.equals(relation, that.relation) &&
+                Objects.equals(filter, that.filter) &&
+                Objects.equals(min, that.min) &&
+                Objects.equals(scopeTerm, that.scopeTerm) &&
+                Objects.equals(resultTerm, that.resultTerm) &&
+                Objects.equals(cause, that.cause) &&
+                Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relation, filter, min, scopeTerm, resultTerm, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -134,16 +134,16 @@ public class CResolveQuery implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CResolveQuery that = (CResolveQuery) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CResolveQuery that = (CResolveQuery)o;
         return Objects.equals(relation, that.relation) &&
-                Objects.equals(filter, that.filter) &&
-                Objects.equals(min, that.min) &&
-                Objects.equals(scopeTerm, that.scopeTerm) &&
-                Objects.equals(resultTerm, that.resultTerm) &&
-                Objects.equals(cause, that.cause) &&
-                Objects.equals(message, that.message);
+            Objects.equals(filter, that.filter) &&
+            Objects.equals(min, that.min) &&
+            Objects.equals(scopeTerm, that.scopeTerm) &&
+            Objects.equals(resultTerm, that.resultTerm) &&
+            Objects.equals(cause, that.cause) &&
+            Objects.equals(message, that.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -91,4 +92,19 @@ public class CTellEdge implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CTellEdge cTellEdge = (CTellEdge) o;
+        return Objects.equals(sourceTerm, cTellEdge.sourceTerm) &&
+                Objects.equals(label, cTellEdge.label) &&
+                Objects.equals(targetTerm, cTellEdge.targetTerm) &&
+                Objects.equals(cause, cTellEdge.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sourceTerm, label, targetTerm, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -94,13 +94,13 @@ public class CTellEdge implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CTellEdge cTellEdge = (CTellEdge) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CTellEdge cTellEdge = (CTellEdge)o;
         return Objects.equals(sourceTerm, cTellEdge.sourceTerm) &&
-                Objects.equals(label, cTellEdge.label) &&
-                Objects.equals(targetTerm, cTellEdge.targetTerm) &&
-                Objects.equals(cause, cTellEdge.cause);
+            Objects.equals(label, cTellEdge.label) &&
+            Objects.equals(targetTerm, cTellEdge.targetTerm) &&
+            Objects.equals(cause, cTellEdge.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellRel.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellRel.java
@@ -94,13 +94,13 @@ public class CTellRel implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CTellRel cTellRel = (CTellRel) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CTellRel cTellRel = (CTellRel)o;
         return Objects.equals(scopeTerm, cTellRel.scopeTerm) &&
-                Objects.equals(relation, cTellRel.relation) &&
-                Objects.equals(datumTerm, cTellRel.datumTerm) &&
-                Objects.equals(cause, cTellRel.cause);
+            Objects.equals(relation, cTellRel.relation) &&
+            Objects.equals(datumTerm, cTellRel.datumTerm) &&
+            Objects.equals(cause, cTellRel.cause);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellRel.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellRel.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -91,4 +92,19 @@ public class CTellRel implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CTellRel cTellRel = (CTellRel) o;
+        return Objects.equals(scopeTerm, cTellRel.scopeTerm) &&
+                Objects.equals(relation, cTellRel.relation) &&
+                Objects.equals(datumTerm, cTellRel.datumTerm) &&
+                Objects.equals(cause, cTellRel.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopeTerm, relation, datumTerm, cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -66,9 +66,9 @@ public class CTrue implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CTrue cTrue = (CTrue) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CTrue cTrue = (CTrue)o;
         return Objects.equals(cause, cTrue.cause);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -63,4 +64,16 @@ public class CTrue implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CTrue cTrue = (CTrue) o;
+        return Objects.equals(cause, cTrue.cause);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cause);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -91,4 +92,18 @@ public class CTry implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CTry cTry = (CTry) o;
+        return Objects.equals(constraint, cTry.constraint) &&
+                Objects.equals(cause, cTry.cause) &&
+                Objects.equals(message, cTry.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(constraint, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -94,12 +94,12 @@ public class CTry implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CTry cTry = (CTry) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CTry cTry = (CTry)o;
         return Objects.equals(constraint, cTry.constraint) &&
-                Objects.equals(cause, cTry.cause) &&
-                Objects.equals(message, cTry.message);
+            Objects.equals(cause, cTry.cause) &&
+            Objects.equals(message, cTry.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -2,6 +2,7 @@ package mb.statix.constraints;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -103,4 +104,19 @@ public class CUser implements IConstraint, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CUser cUser = (CUser) o;
+        return Objects.equals(name, cUser.name) &&
+                Objects.equals(args, cUser.args) &&
+                Objects.equals(cause, cUser.cause) &&
+                Objects.equals(message, cUser.message);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, args, cause, message);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -106,13 +106,13 @@ public class CUser implements IConstraint, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CUser cUser = (CUser) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        CUser cUser = (CUser)o;
         return Objects.equals(name, cUser.name) &&
-                Objects.equals(args, cUser.args) &&
-                Objects.equals(cause, cUser.cause) &&
-                Objects.equals(message, cUser.message);
+            Objects.equals(args, cUser.args) &&
+            Objects.equals(cause, cUser.cause) &&
+            Objects.equals(message, cUser.message);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/Message.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/Message.java
@@ -71,12 +71,12 @@ public class Message implements IMessage, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Message message = (Message) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        Message message = (Message)o;
         return kind == message.kind &&
-                Objects.equals(content, message.content) &&
-                Objects.equals(origin, message.origin);
+            Objects.equals(content, message.content) &&
+            Objects.equals(origin, message.origin);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/Message.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/Message.java
@@ -2,6 +2,7 @@ package mb.statix.constraints.messages;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -67,5 +68,19 @@ public class Message implements IMessage, Serializable {
         sb.append("]");
         return sb.toString();
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Message message = (Message) o;
+        return kind == message.kind &&
+                Objects.equals(content, message.content) &&
+                Objects.equals(origin, message.origin);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, content, origin);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/TermPart.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/TermPart.java
@@ -39,9 +39,9 @@ public class TermPart implements IMessagePart, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TermPart termPart = (TermPart) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        TermPart termPart = (TermPart)o;
         return Objects.equals(term, termPart.term);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/TermPart.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/TermPart.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints.messages;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.substitution.IRenaming;
@@ -36,4 +37,16 @@ public class TermPart implements IMessagePart, Serializable {
         return sb.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermPart termPart = (TermPart) o;
+        return Objects.equals(term, termPart.term);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(term);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/TextPart.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/TextPart.java
@@ -34,9 +34,9 @@ public class TextPart implements IMessagePart, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TextPart textPart = (TextPart) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        TextPart textPart = (TextPart)o;
         return Objects.equals(text, textPart.text);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/messages/TextPart.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/messages/TextPart.java
@@ -1,6 +1,7 @@
 package mb.statix.constraints.messages;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import mb.nabl2.terms.substitution.IRenaming;
 import mb.nabl2.terms.substitution.ISubstitution;
@@ -31,4 +32,16 @@ public class TextPart implements IMessagePart, Serializable {
         return text;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TextPart textPart = (TextPart) o;
+        return Objects.equals(text, textPart.text);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
@@ -67,11 +67,11 @@ public class QueryFilter implements IQueryFilter, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        QueryFilter that = (QueryFilter) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        QueryFilter that = (QueryFilter)o;
         return Objects.equals(pathWf, that.pathWf) &&
-                Objects.equals(dataWf, that.dataWf);
+            Objects.equals(dataWf, that.dataWf);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
@@ -1,6 +1,7 @@
 package mb.statix.solver.query;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
@@ -64,4 +65,17 @@ public class QueryFilter implements IQueryFilter, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryFilter that = (QueryFilter) o;
+        return Objects.equals(pathWf, that.pathWf) &&
+                Objects.equals(dataWf, that.dataWf);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pathWf, dataWf);
+    }
 }

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
@@ -61,11 +61,11 @@ public class QueryMin implements IQueryMin, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        QueryMin queryMin = (QueryMin) o;
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        QueryMin queryMin = (QueryMin)o;
         return Objects.equals(labelOrd, queryMin.labelOrd) &&
-                Objects.equals(dataOrd, queryMin.dataOrd);
+            Objects.equals(dataOrd, queryMin.dataOrd);
     }
 
     @Override

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
@@ -1,6 +1,7 @@
 package mb.statix.solver.query;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
@@ -58,4 +59,17 @@ public class QueryMin implements IQueryMin, Serializable {
         return toString(ITerm::toString);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QueryMin queryMin = (QueryMin) o;
+        return Objects.equals(labelOrd, queryMin.labelOrd) &&
+                Objects.equals(dataOrd, queryMin.dataOrd);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(labelOrd, dataOrd);
+    }
 }


### PR DESCRIPTION
This PR implements `hashCode` and `equals` on all (transitive) subfields of `Rule`.