### PR TITLE
Ambiguous test

### DIFF
--- a/statix.test/syntax/regex.spt
+++ b/statix.test/syntax/regex.spt
@@ -73,8 +73,7 @@ test not & closure < or [[
 
 test pre-post-fix ambiguity [[
   ~P*
-]] parse succeeds
-   warning like "amb"
+]] parse ambiguous
 
 test and < or [[
   ~P | Q* & LEX?


### PR DESCRIPTION
This PR fixes a test that asserts that the parse is ambiguous.

Depends on:
- metaborg/spt#31