### PR TITLE
Fix Appl ambiguity in namespaces

### DIFF
--- a/statix.lang/syntax/statix/lang/Core.sdf3
+++ b/statix.lang/syntax/statix/lang/Core.sdf3
@@ -242,7 +242,7 @@ context-free syntax
   // little duplication to fix ambiguity between
   // As(Var(_),Var(_)), NoId() and Var(_), WithId(Var(_))
   OccurrenceTerms = <<{OccurrenceTerm " "}*>>
-  OccurrenceTerm  = Term
+  OccurrenceTerm  = Term {longest-match}
   OccurrenceTerm  = <<Var>@<Term>> {reject}
 
 syntax


### PR DESCRIPTION
[This thread](https://slde.slack.com/archives/C7254SF60/p1612277539105800) shows that, inside an occurrence production, the term `C(_)` can be ambiguous: it can be parsed as a constructor application, or the `(_)` can be parsed a second, bracketed, argument to the occurrence.

I fixed it by adding a `{longest-match}` on the injection on `OccurrenceTerm`. Maybe not the most clean, but using priorities in list and bracket productions is really tedious, as is redefining `OccurrenceTerm` not to accept bracket terms. Moreover, this might fix other lurking ambiguities in one shot.