### PR TITLE
Add flags to trigger eager solver returns on errors or delays

### DIFF
--- a/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/regexp/RegExpMatcher.java
@@ -156,6 +156,21 @@ public class RegExpMatcher<S> implements IRegExpMatcher<S>, Serializable {
             this.regexp = regexp;
         }
 
+        @Override public int hashCode() {
+            return Objects.hash(regexp);
+        }
+
+        @Override public boolean equals(Object obj) {
+            if(this == obj)
+                return true;
+            if(obj == null)
+                return false;
+            if(getClass() != obj.getClass())
+                return false;
+            State<?> other = (State<?>) obj;
+            return Objects.equals(regexp, other.regexp);
+        }
+
         @Override public String toString() {
             return regexp.toString();
         }

--- a/statix.solver/src/main/java/mb/statix/concurrent/actors/impl/ThreadPoolScheduler.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/actors/impl/ThreadPoolScheduler.java
@@ -1,0 +1,71 @@
+package mb.statix.concurrent.actors.impl;
+
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.metaborg.util.log.ILogger;
+import org.metaborg.util.log.LoggerUtils;
+
+public class ThreadPoolScheduler implements IActorScheduler {
+
+    private static final ILogger logger = LoggerUtils.logger(ThreadPoolScheduler.class);
+
+    private final ThreadPoolExecutor executor;
+
+    public ThreadPoolScheduler(int parallelism) {
+        this.executor =
+                new ThreadPoolExecutor(parallelism, parallelism, 60L, TimeUnit.SECONDS, new LinkedBlockingDeque<>());
+    }
+
+    @Override public boolean isActive() {
+        return executor.getActiveCount() != 0 || !executor.getQueue().isEmpty();
+    }
+
+    @Override public void schedule(Runnable runnable, @SuppressWarnings("unused") int priority,
+            AtomicReference<Runnable> taskRef) {
+        final Task task = new Task(runnable);
+        if(!taskRef.compareAndSet(null, task)) {
+            logger.error("Actor {} already scheduled", runnable);
+            throw new IllegalStateException("Actor " + runnable + " already scheduled.");
+        }
+        executor.execute(task);
+    }
+
+    @SuppressWarnings("unused") @Override public void reschedule(Runnable oldTask, int newPriority,
+            AtomicReference<Runnable> taskRef) {
+    }
+
+    @SuppressWarnings("unused") @Override public boolean preempt(int priority) {
+        return false;
+    }
+
+    @Override public void shutdown() {
+        executor.shutdown();
+    }
+
+    @Override public void shutdownNow() {
+        executor.shutdownNow();
+    }
+
+    private class Task implements Runnable {
+
+        private final Runnable runnable;
+        private final AtomicBoolean active;
+
+        Task(Runnable runnable) {
+            this.runnable = runnable;
+            this.active = new AtomicBoolean(true);
+        }
+
+        @Override public void run() {
+            if(active.compareAndSet(true, false)) {
+                runnable.run();
+            }
+        }
+
+    }
+
+}

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/PRaffrayiUtil.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/PRaffrayiUtil.java
@@ -18,7 +18,7 @@ public class PRaffrayiUtil {
                 out.println(formatLine("unit", unitResult.stats().csvHeaders()));
                 first = false;
             }
-            System.out.println(formatLine(unitResult.id(), unitResult.stats().csvRow()));
+            out.println(formatLine(unitResult.id(), unitResult.stats().csvRow()));
         }
     }
 

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/Unit.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/Unit.java
@@ -496,6 +496,7 @@ class Unit<S, L, D, R> implements IUnit<S, L, D, R>, IActorMonitor, Host<IActorR
             }
 
             @Override protected IFuture<Boolean> dataWf(D d, ICancel cancel) throws InterruptedException {
+                stats.dataWfChecks += 1;
                 final ICompletableFuture<Boolean> result = new CompletableFuture<>();
                 if(external || dataWfInternal == null) {
                     dataWF.wf(d, queryContext, cancel).whenComplete(result::complete);
@@ -511,6 +512,7 @@ class Unit<S, L, D, R> implements IUnit<S, L, D, R>, IActorMonitor, Host<IActorR
             }
 
             @Override protected IFuture<Boolean> dataLeq(D d1, D d2, ICancel cancel) throws InterruptedException {
+                stats.dataLeqChecks += 1;
                 final ICompletableFuture<Boolean> result = new CompletableFuture<>();
                 if(external || dataEquivInternal == null) {
                     dataEquiv.leq(d1, d2, queryContext, cancel).whenComplete(result::complete);
@@ -873,6 +875,8 @@ class Unit<S, L, D, R> implements IUnit<S, L, D, R>, IActorMonitor, Host<IActorR
         private int outgoingQueries;
         private int forwardedQueries;
         private long runtimeNanos;
+        private int dataWfChecks;
+        private int dataLeqChecks;
 
         private IActorStats actorStats;
 
@@ -883,11 +887,13 @@ class Unit<S, L, D, R> implements IUnit<S, L, D, R>, IActorMonitor, Host<IActorR
         @Override public Iterable<String> csvHeaders() {
             // @formatter:off
             return Iterables.concat(ImmutableList.of(
+                "runtimeMillis",
                 "localQueries",
                 "incomingQueries",
                 "outgoingQueries",
                 "forwardedQueries",
-                "runtimeMillis"
+                "dataWfChecks",
+                "dataLeqChecks"
             ), actorStats.csvHeaders());
             // @formatter:on
         }
@@ -895,11 +901,13 @@ class Unit<S, L, D, R> implements IUnit<S, L, D, R>, IActorMonitor, Host<IActorR
         @Override public Iterable<String> csvRow() {
             // @formatter:off
             return Iterables.concat(ImmutableList.of(
+                Long.toString(TimeUnit.MILLISECONDS.convert(runtimeNanos, TimeUnit.NANOSECONDS)),
                 Integer.toString(localQueries),
                 Integer.toString(incomingQueries),
                 Integer.toString(outgoingQueries),
                 Integer.toString(forwardedQueries),
-                Long.toString(TimeUnit.MILLISECONDS.convert(runtimeNanos, TimeUnit.NANOSECONDS))
+                Integer.toString(dataWfChecks),
+                Integer.toString(dataLeqChecks)
             ), actorStats.csvRow());
             // @formatter:on
         }

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/AQuery.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/AQuery.java
@@ -12,7 +12,7 @@ import mb.statix.concurrent.p_raffrayi.nameresolution.LabelWf;
 import mb.statix.scopegraph.path.IScopePath;
 import mb.statix.scopegraph.reference.Env;
 
-@Value.Immutable(prehash = true)
+@Value.Immutable(prehash = false)
 public abstract class AQuery<S, L, D> implements IWaitFor<S, L, D> {
 
     @Override @Value.Parameter public abstract IActorRef<? extends IUnit<S, L, D, ?>> origin();
@@ -48,7 +48,7 @@ public abstract class AQuery<S, L, D> implements IWaitFor<S, L, D> {
      */
 
     @Override public int hashCode() {
-        return System.identityHashCode(this);
+        return super.hashCode();
     }
 
     @Override public boolean equals(Object obj) {

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/ATypeCheckerResult.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/ATypeCheckerResult.java
@@ -6,7 +6,7 @@ import mb.statix.concurrent.actors.IActorRef;
 import mb.statix.concurrent.actors.futures.ICompletableFuture;
 import mb.statix.concurrent.p_raffrayi.impl.IUnit;
 
-@Value.Immutable(prehash = true)
+@Value.Immutable(prehash = false)
 public abstract class ATypeCheckerResult<S, L, D> implements IWaitFor<S, L, D> {
 
     @Override @Value.Parameter public abstract IActorRef<? extends IUnit<S, L, D, ?>> origin();
@@ -15,6 +15,21 @@ public abstract class ATypeCheckerResult<S, L, D> implements IWaitFor<S, L, D> {
 
     @Override public void visit(Cases<S, L, D> cases) {
         cases.on((TypeCheckerResult<S, L, D>) this);
+    }
+
+    /*
+     * CAREFUL
+     * For this class, hashCode and equals are simplified to reference equality for performance.
+     * This is possible because we never create a new instance which is used in isWaitingFor.
+     * The tokens CloseScope & CloseLabel are created for such checks, and must have structural equality.
+     */
+
+    @Override public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override public boolean equals(Object obj) {
+        return this == obj;
     }
 
 }

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/ATypeCheckerState.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/tokens/ATypeCheckerState.java
@@ -8,7 +8,7 @@ import mb.statix.concurrent.actors.IActorRef;
 import mb.statix.concurrent.actors.futures.ICompletableFuture;
 import mb.statix.concurrent.p_raffrayi.impl.IUnit;
 
-@Value.Immutable(prehash = true)
+@Value.Immutable(prehash = false)
 public abstract class ATypeCheckerState<S, L, D> implements IWaitFor<S, L, D> {
 
     @Override @Value.Parameter public abstract IActorRef<? extends IUnit<S, L, D, ?>> origin();
@@ -29,7 +29,7 @@ public abstract class ATypeCheckerState<S, L, D> implements IWaitFor<S, L, D> {
      */
 
     @Override public int hashCode() {
-        return System.identityHashCode(this);
+        return super.hashCode();
     }
 
     @Override public boolean equals(Object obj) {

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/LabelWf.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/LabelWf.java
@@ -9,17 +9,23 @@ public interface LabelWf<L> {
     boolean accepting();
 
     static <L> LabelWf<L> any() {
-        return new LabelWf<L>() {
-
-            @Override public boolean accepting() {
-                return true;
-            }
-
-            @Override public Optional<LabelWf<L>> step(L l) {
-                return Optional.of(this);
-            }
-
-        };
+        return ANY;
     }
+
+    static final LabelWf ANY = new LabelWf() {
+
+        @Override public boolean accepting() {
+            return true;
+        }
+
+        @Override public Optional<LabelWf> step(Object l) {
+            return Optional.of(this);
+        }
+
+        @Override public String toString() {
+            return ".*";
+        }
+
+    };
 
 }

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/RegExpLabelWf.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/RegExpLabelWf.java
@@ -1,5 +1,6 @@
 package mb.statix.concurrent.p_raffrayi.nameresolution;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import mb.nabl2.regexp.IRegExpMatcher;
@@ -23,6 +24,21 @@ public class RegExpLabelWf<L> implements LabelWf<L> {
 
     @Override public boolean accepting() {
         return re.isAccepting();
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(re);
+    }
+
+    @Override public boolean equals(Object obj) {
+        if(this == obj)
+            return true;
+        if(obj == null)
+            return false;
+        if(getClass() != obj.getClass())
+            return false;
+        RegExpLabelWf<?> other = (RegExpLabelWf<?>) obj;
+        return Objects.equals(re, other.re);
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/concurrent/solver/AProjectResult.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/solver/AProjectResult.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import org.immutables.value.Value;
+import org.metaborg.util.unit.Unit;
 
 import mb.nabl2.terms.ITerm;
 import mb.statix.concurrent.p_raffrayi.IUnitResult;
@@ -15,6 +16,8 @@ import mb.statix.solver.persistent.SolverResult;
 public abstract class AProjectResult implements IStatixResult {
 
     @Value.Parameter public abstract String resource();
+
+    @Value.Parameter public abstract Map<String, IUnitResult<Scope, ITerm, ITerm, Unit>> libraryResults();
 
     @Value.Parameter public abstract Map<String, IUnitResult<Scope, ITerm, ITerm, GroupResult>> groupResults();
 

--- a/statix.solver/src/main/java/mb/statix/concurrent/solver/ProjectTypeChecker.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/solver/ProjectTypeChecker.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
+import org.metaborg.util.unit.Unit;
 
 import mb.nabl2.terms.ITerm;
 import mb.statix.concurrent.actors.futures.AggregateFuture;
@@ -32,20 +33,21 @@ public class ProjectTypeChecker extends AbstractTypeChecker<ProjectResult> {
             @SuppressWarnings("unused") List<Scope> rootScopes) {
         final Scope projectScope = makeSharedScope(context, "s_prj");
 
+        final IFuture<Map<String, IUnitResult<Scope, ITerm, ITerm, Unit>>> libraryResults =
+                runLibraries(context, project.libraries(), projectScope);
+
         final IFuture<Map<String, IUnitResult<Scope, ITerm, ITerm, GroupResult>>> groupResults =
                 runGroups(context, project.groups(), projectScope);
 
         final IFuture<Map<String, IUnitResult<Scope, ITerm, ITerm, UnitResult>>> unitResults =
                 runUnits(context, project.units(), projectScope);
 
-        runLibraries(context, project.libraries(), projectScope);
-
         context.closeScope(projectScope);
 
         final IFuture<SolverResult> result = runSolver(context, project.rule(), Arrays.asList(projectScope));
 
-        return AggregateFuture.apply(groupResults, unitResults, result).thenApply(e -> {
-            return ProjectResult.of(project.resource(), e._1(), e._2(), e._3(), null);
+        return AggregateFuture.apply(libraryResults, groupResults, unitResults, result).thenApply(e -> {
+            return ProjectResult.of(project.resource(), e._1(), e._2(), e._3(), e._4(), null);
         }).whenComplete((r, ex) -> {
             logger.debug("project {}: returned.", context.id());
         });

--- a/statix.solver/src/main/java/mb/statix/scopegraph/reference/Env.java
+++ b/statix.solver/src/main/java/mb/statix/scopegraph/reference/Env.java
@@ -18,6 +18,10 @@ public class Env<S, L, D> implements Iterable<ResolutionPath<S, L, D>> {
         this.paths = paths;
     }
 
+    public int size() {
+        return paths.size();
+    }
+
     public boolean isEmpty() {
         return paths.isEmpty();
     }

--- a/statix.solver/src/main/java/mb/statix/spoofax/STX_solve_multi.java
+++ b/statix.solver/src/main/java/mb/statix/spoofax/STX_solve_multi.java
@@ -14,6 +14,7 @@ import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 import org.metaborg.util.task.ICancel;
 import org.metaborg.util.task.IProgress;
+import org.metaborg.util.unit.Unit;
 import org.spoofax.interpreter.core.IContext;
 import org.spoofax.interpreter.core.InterpreterException;
 
@@ -26,6 +27,7 @@ import mb.nabl2.terms.ITerm;
 import mb.statix.concurrent.actors.futures.IFuture;
 import mb.statix.concurrent.p_raffrayi.IScopeImpl;
 import mb.statix.concurrent.p_raffrayi.IUnitResult;
+import mb.statix.concurrent.p_raffrayi.PRaffrayiUtil;
 import mb.statix.concurrent.p_raffrayi.impl.Broker;
 import mb.statix.concurrent.p_raffrayi.impl.ScopeImpl;
 import mb.statix.concurrent.solver.GroupResult;
@@ -81,7 +83,7 @@ public class STX_solve_multi extends StatixPrimitive {
             final List<IUnitResult<Scope, ITerm, ITerm, ?>> unitResults = new ArrayList<>();
             final Map<String, SolverResult> resultMap = flattenResult(spec, result, unitResults);
 
-            //            PRaffrayiUtil.writeStatsCsvFromResult(unitResults, System.out);
+            // PRaffrayiUtil.writeStatsCsvFromResult(unitResults, System.out);
 
             logger.info("Files analyzed in {} s", (dt / 1_000d));
 
@@ -113,6 +115,7 @@ public class STX_solve_multi extends StatixPrimitive {
         final ProjectResult projectResult = result.analysis();
         if(projectResult != null) {
             final List<SolverResult> groupResults = new ArrayList<>();
+            projectResult.libraryResults().forEach((k, ur) -> flattenLibraryResult(spec, ur, unitResults));
             projectResult.groupResults()
                     .forEach((k, gr) -> flattenGroupResult(spec, gr, groupResults, resourceResults, unitResults));
             projectResult.unitResults().forEach((k, ur) -> flattenUnitResult(spec, ur, resourceResults, unitResults));
@@ -125,6 +128,11 @@ public class STX_solve_multi extends StatixPrimitive {
             logger.error("Missing result for project {}", result.id());
         }
         return resourceResults;
+    }
+
+    private void flattenLibraryResult(Spec spec, IUnitResult<Scope, ITerm, ITerm, Unit> result,
+            List<IUnitResult<Scope, ITerm, ITerm, ?>> unitResults) {
+        unitResults.add(result);
     }
 
     private void flattenGroupResult(Spec spec, IUnitResult<Scope, ITerm, ITerm, GroupResult> result,


### PR DESCRIPTION
When the solver is used to check entailment, it is not necessary to continue
solving after the first error or delay is detected. This PR introduces flags
that can be passed to the solver to trigger such eager returns.

Before this can be merged, a review is necessary to determine what the exact
behavior of the concurrent framework is after the type checker returns a
result. After the type checker returns, the framework should not deliver any
more messages, should not schedule completion of futures, or in any other way
allow the type cehcker to resume execution. I don't think that is currently the
case. The code in the solver has some basic checks to prevent reactivation
after returning eagerly, but this should be the responsibility of the
concurrent framework.