### PR TITLE
Reintroduce optimized name resolution when dataLeq is always true

### DIFF
--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/AbstractUnit.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/impl/AbstractUnit.java
@@ -452,6 +452,10 @@ public abstract class AbstractUnit<S, L, D, R>
                 }
             }
 
+            public IFuture<Boolean> dataLeqAlwaysTrue(ICancel cancel) {
+                return dataEquiv.alwaysTrue(queryContext, cancel);
+            }
+
         };
 
         final IFuture<Env<S, L, D>> result = nr.env(path, labelWF, context.cancel());

--- a/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/DataLeq.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/p_raffrayi/nameresolution/DataLeq.java
@@ -10,10 +10,18 @@ public interface DataLeq<S, L, D> {
 
     IFuture<Boolean> leq(D d1, D d2, ITypeCheckerContext<S, L, D> context, ICancel cancel) throws InterruptedException;
 
+    default IFuture<Boolean> alwaysTrue(ITypeCheckerContext<S, L, D> context, ICancel cancel) {
+        return CompletableFuture.completedFuture(false);
+    }
+
     static <S, L, D> DataLeq<S, L, D> any() {
         return new DataLeq<S, L, D>() {
             @SuppressWarnings("unused") @Override public IFuture<Boolean> leq(D d1, D d2,
                     ITypeCheckerContext<S, L, D> context, ICancel cancel) throws InterruptedException {
+                return CompletableFuture.completedFuture(true);
+            }
+
+            @Override public IFuture<Boolean> alwaysTrue(ITypeCheckerContext<S, L, D> context, ICancel cancel) {
                 return CompletableFuture.completedFuture(true);
             }
         };

--- a/statix.solver/src/main/java/mb/statix/concurrent/solver/StatixSolver.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/solver/StatixSolver.java
@@ -1085,9 +1085,10 @@ public class StatixSolver {
                             ImmutableList.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT)
                             .orElse(null)) == null) {
                         alwaysTrue = CompletableFuture.completedFuture(false);
+                    } else {
+                        alwaysTrue = entails(context, spec, state, result.body(), result.criticalEdges(),
+                                new NullDebugContext(), cancel, new NullProgress());
                     }
-                    alwaysTrue = entails(context, spec, state, result.body(), result.criticalEdges(),
-                            new NullDebugContext(), cancel, new NullProgress());
                 } catch(Delay e) {
                     throw new IllegalStateException("Unexpected delay.", e);
                 }
@@ -1141,7 +1142,7 @@ public class StatixSolver {
                                 .apply(d2_state._2().unifier(), constraint,
                                         ImmutableList.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT)
                                 .orElse(null)) == null) {
-                            alwaysTrue.complete(false);
+                            return CompletableFuture.completedFuture(false);
                         }
                         return entails(context, spec, state, result.body(), result.criticalEdges(),
                                 new NullDebugContext(), cancel, new NullProgress());

--- a/statix.solver/src/main/java/mb/statix/concurrent/solver/StatixSolver.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/solver/StatixSolver.java
@@ -17,6 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.metaborg.util.functions.CheckedAction0;
 import org.metaborg.util.functions.Function0;
 import org.metaborg.util.log.Level;
@@ -49,6 +51,7 @@ import mb.nabl2.terms.unification.ud.IUniDisunifier;
 import mb.nabl2.util.CapsuleUtil;
 import mb.nabl2.util.Tuple2;
 import mb.statix.concurrent.actors.futures.CompletableFuture;
+import mb.statix.concurrent.actors.futures.ICompletableFuture;
 import mb.statix.concurrent.actors.futures.IFuture;
 import mb.statix.concurrent.p_raffrayi.DeadlockException;
 import mb.statix.concurrent.p_raffrayi.ITypeCheckerContext;
@@ -1068,6 +1071,30 @@ public class StatixSolver {
             }
         }
 
+        private @Nullable IFuture<Boolean> alwaysTrue;
+
+        @Override public IFuture<Boolean> alwaysTrue(ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) {
+            if(alwaysTrue == null) {
+                try {
+                    final ApplyResult result;
+                    final Tuple2<ITermVar, IState.Immutable> d1_state =
+                            state.freshVar(B.newVar(state.resource(), "d1"));
+                    final Tuple2<ITermVar, IState.Immutable> d2_state =
+                            d1_state._2().freshVar(B.newVar(state.resource(), "d2"));
+                    if((result = RuleUtil.apply(d2_state._2().unifier(), constraint,
+                            ImmutableList.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT)
+                            .orElse(null)) == null) {
+                        alwaysTrue = CompletableFuture.completedFuture(false);
+                    }
+                    alwaysTrue = entails(context, spec, state, result.body(), result.criticalEdges(),
+                            new NullDebugContext(), cancel, new NullProgress());
+                } catch(Delay e) {
+                    throw new IllegalStateException("Unexpected delay.", e);
+                }
+            }
+            return alwaysTrue;
+        }
+
         @Override public String toString() {
             return constraint.toString(state.unifier()::toString);
         }
@@ -1096,6 +1123,34 @@ public class StatixSolver {
                     return CompletableFuture.completedExceptionally(delay);
                 }
             });
+        }
+
+        private @Nullable ICompletableFuture<Boolean> alwaysTrue;
+
+        @Override public IFuture<Boolean> alwaysTrue(ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) {
+            if(alwaysTrue == null) {
+                alwaysTrue = new CompletableFuture<>();
+                absorbDelays(() -> {
+                    try {
+                        final ApplyResult result;
+                        final Tuple2<ITermVar, IState.Immutable> d1_state =
+                                state.freshVar(B.newVar(state.resource(), "d1"));
+                        final Tuple2<ITermVar, IState.Immutable> d2_state =
+                                d1_state._2().freshVar(B.newVar(state.resource(), "d2"));
+                        if((result = RuleUtil
+                                .apply(d2_state._2().unifier(), constraint,
+                                        ImmutableList.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT)
+                                .orElse(null)) == null) {
+                            alwaysTrue.complete(false);
+                        }
+                        return entails(context, spec, state, result.body(), result.criticalEdges(),
+                                new NullDebugContext(), cancel, new NullProgress());
+                    } catch(Delay delay) {
+                        return CompletableFuture.completedExceptionally(delay);
+                    }
+                }).whenComplete(alwaysTrue::complete);
+            }
+            return alwaysTrue;
         }
 
         @Override public String toString() {


### PR DESCRIPTION
Introduced an optimization where shadowed subgraphs are not queried. In this version (in contrast to the commented version), `DataLeq#alwaysTrue` is asynchronous, because it relies on `StatixSolver#entails`, which is asynchronous as well. 

Before merging, there is one point of consideration. The non-internal `DataLeq` instances can be shared between units. That might that imply that their `alwaysTrue` method can be invoked from different threads at the same time (is that actually the case???). If that is the case, we might accidentally create multiple `alwaysTrue` instances, while we intend to create one. I don't think it gives invalid results, but it would be good to synchronize in such situations.