### PR TITLE
Bugfix/nested completeness

### DIFF
--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -491,7 +491,7 @@ class GreedySolver {
                 }
 
                 try {
-                    final ConstraintQueries cq = new ConstraintQueries(spec, state);
+                    final ConstraintQueries cq = new ConstraintQueries(spec, state, completeness);
                     // @formatter:off
                     final INameResolution<Scope, ITerm, ITerm> nameResolution = Solver.nameResolutionBuilder()
                                 .withLabelWF(cq.getLabelWF(filter.getLabelWF()))

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -491,7 +491,7 @@ class GreedySolver {
                 }
 
                 try {
-                    final ConstraintQueries cq = new ConstraintQueries(spec, state, completeness);
+                    final ConstraintQueries cq = new ConstraintQueries(spec, state, params::isComplete);
                     // @formatter:off
                     final INameResolution<Scope, ITerm, ITerm> nameResolution = Solver.nameResolutionBuilder()
                                 .withLabelWF(cq.getLabelWF(filter.getLabelWF()))

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
@@ -13,7 +13,7 @@ import mb.scopegraph.oopsla20.reference.ResolutionException;
 import mb.statix.constraints.Constraints;
 import mb.statix.solver.Delay;
 import mb.statix.solver.IState;
-import mb.statix.solver.completeness.ICompleteness;
+import mb.statix.solver.completeness.IsComplete;
 import mb.statix.solver.log.NullDebugContext;
 import mb.statix.solver.persistent.Solver;
 import mb.statix.solver.query.ResolutionDelayException;
@@ -30,12 +30,12 @@ class ConstraintDataLeq implements DataLeq<ITerm> {
     private final Rule constraint;
 
     private final IState.Immutable state;
-    private final ICompleteness.Immutable completeness;
+    private final IsComplete isComplete;
 
-    public ConstraintDataLeq(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness, Rule constraint) {
+    public ConstraintDataLeq(Spec spec, IState.Immutable state, IsComplete isComplete, Rule constraint) {
         this.spec = spec;
         this.state = state;
-        this.completeness = completeness;
+        this.isComplete = isComplete;
         this.constraint = constraint;
     }
 
@@ -49,8 +49,8 @@ class ConstraintDataLeq implements DataLeq<ITerm> {
             }
 
             return Solver.entails(spec, state, Constraints.disjoin(applyResult.body()), Collections.emptyMap(),
-                    applyResult.criticalEdges(), (s, l, st) -> completeness.isComplete(s, l, state.unifier()),
-                    new NullDebugContext(), new NullProgress().subProgress(1), new NullCancel());
+                    applyResult.criticalEdges(), isComplete, new NullDebugContext(),
+                    new NullProgress().subProgress(1), new NullCancel());
         } catch(Delay d) {
             throw new ResolutionDelayException("Data order delayed.", d);
         }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
@@ -13,7 +13,7 @@ import mb.scopegraph.oopsla20.reference.ResolutionException;
 import mb.statix.constraints.Constraints;
 import mb.statix.solver.Delay;
 import mb.statix.solver.IState;
-import mb.statix.solver.completeness.IsComplete;
+import mb.statix.solver.completeness.ICompleteness;
 import mb.statix.solver.log.NullDebugContext;
 import mb.statix.solver.persistent.Solver;
 import mb.statix.solver.query.ResolutionDelayException;
@@ -30,11 +30,13 @@ class ConstraintDataLeq implements DataLeq<ITerm> {
     private final Rule constraint;
 
     private final IState.Immutable state;
+    private final ICompleteness.Immutable completeness;
 
-    public ConstraintDataLeq(Spec spec, IState.Immutable state, Rule constraint) {
+    public ConstraintDataLeq(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness, Rule constraint) {
         this.spec = spec;
-        this.constraint = constraint;
         this.state = state;
+        this.completeness = completeness;
+        this.constraint = constraint;
     }
 
     @Override public boolean leq(ITerm datum1, ITerm datum2) throws ResolutionException, InterruptedException {
@@ -47,8 +49,8 @@ class ConstraintDataLeq implements DataLeq<ITerm> {
             }
 
             return Solver.entails(spec, state, Constraints.disjoin(applyResult.body()), Collections.emptyMap(),
-                    applyResult.criticalEdges(), IsComplete.ALWAYS, new NullDebugContext(),
-                    new NullProgress().subProgress(1), new NullCancel());
+                    applyResult.criticalEdges(), (s, l, st) -> completeness.isComplete(s, l, state.unifier()),
+                    new NullDebugContext(), new NullProgress().subProgress(1), new NullCancel());
         } catch(Delay d) {
             throw new ResolutionDelayException("Data order delayed.", d);
         }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
@@ -13,7 +13,7 @@ import mb.scopegraph.oopsla20.reference.ResolutionException;
 import mb.statix.constraints.Constraints;
 import mb.statix.solver.Delay;
 import mb.statix.solver.IState;
-import mb.statix.solver.completeness.IsComplete;
+import mb.statix.solver.completeness.ICompleteness;
 import mb.statix.solver.log.NullDebugContext;
 import mb.statix.solver.persistent.Solver;
 import mb.statix.solver.query.ResolutionDelayException;
@@ -30,11 +30,13 @@ class ConstraintDataWF implements DataWF<ITerm> {
     private final Rule constraint;
 
     private final IState.Immutable state;
+    private final ICompleteness.Immutable completeness;
 
-    public ConstraintDataWF(Spec spec, IState.Immutable state, Rule constraint) {
+    public ConstraintDataWF(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness, Rule constraint) {
         this.spec = spec;
-        this.constraint = constraint;
         this.state = state;
+        this.completeness = completeness;
+        this.constraint = constraint;
     }
 
     @Override public boolean wf(ITerm datum) throws ResolutionException, InterruptedException {
@@ -48,8 +50,8 @@ class ConstraintDataWF implements DataWF<ITerm> {
             }
 
             return Solver.entails(spec, state, Constraints.disjoin(applyResult.body()), Collections.emptyMap(),
-                    applyResult.criticalEdges(), IsComplete.ALWAYS, new NullDebugContext(),
-                    new NullProgress().subProgress(1), new NullCancel());
+                    applyResult.criticalEdges(), (s, l, st) -> completeness.isComplete(s, l, state.unifier()),
+                    new NullDebugContext(), new NullProgress().subProgress(1), new NullCancel());
         } catch(Delay d) {
             throw new ResolutionDelayException("Data well-formedness delayed.", d);
         }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
@@ -13,7 +13,7 @@ import mb.scopegraph.oopsla20.reference.ResolutionException;
 import mb.statix.constraints.Constraints;
 import mb.statix.solver.Delay;
 import mb.statix.solver.IState;
-import mb.statix.solver.completeness.ICompleteness;
+import mb.statix.solver.completeness.IsComplete;
 import mb.statix.solver.log.NullDebugContext;
 import mb.statix.solver.persistent.Solver;
 import mb.statix.solver.query.ResolutionDelayException;
@@ -30,12 +30,12 @@ class ConstraintDataWF implements DataWF<ITerm> {
     private final Rule constraint;
 
     private final IState.Immutable state;
-    private final ICompleteness.Immutable completeness;
+    private final IsComplete isComplete;
 
-    public ConstraintDataWF(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness, Rule constraint) {
+    public ConstraintDataWF(Spec spec, IState.Immutable state, IsComplete isComplete, Rule constraint) {
         this.spec = spec;
         this.state = state;
-        this.completeness = completeness;
+        this.isComplete = isComplete;
         this.constraint = constraint;
     }
 
@@ -50,8 +50,8 @@ class ConstraintDataWF implements DataWF<ITerm> {
             }
 
             return Solver.entails(spec, state, Constraints.disjoin(applyResult.body()), Collections.emptyMap(),
-                    applyResult.criticalEdges(), (s, l, st) -> completeness.isComplete(s, l, state.unifier()),
-                    new NullDebugContext(), new NullProgress().subProgress(1), new NullCancel());
+                    applyResult.criticalEdges(), isComplete, new NullDebugContext(),
+                    new NullProgress().subProgress(1), new NullCancel());
         } catch(Delay d) {
             throw new ResolutionDelayException("Data well-formedness delayed.", d);
         }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
@@ -12,6 +12,7 @@ import mb.scopegraph.regexp.IRegExpMatcher;
 import mb.scopegraph.relations.IRelation;
 import mb.statix.solver.IState;
 import mb.statix.solver.completeness.ICompleteness;
+import mb.statix.solver.completeness.IsComplete;
 import mb.statix.solver.query.IConstraintQueries;
 import mb.statix.spec.Rule;
 import mb.statix.spec.Spec;
@@ -20,12 +21,12 @@ public class ConstraintQueries implements IConstraintQueries {
 
     private final Spec spec;
     private final IState.Immutable state;
-    private final ICompleteness.Immutable completeness;
+    private final IsComplete isComplete;
 
-    public ConstraintQueries(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness) {
+    public ConstraintQueries(Spec spec, IState.Immutable state, IsComplete isComplete) {
         this.spec = spec;
         this.state = state;
-        this.completeness = completeness;
+        this.isComplete = isComplete;
     }
 
     @Override public LabelWF<ITerm> getLabelWF(IRegExpMatcher<ITerm> pathWf) throws InterruptedException {
@@ -33,7 +34,7 @@ public class ConstraintQueries implements IConstraintQueries {
     }
 
     @Override public DataWF<ITerm> getDataWF(Rule dataWf) {
-        return new ConstraintDataWF(spec, state, completeness, dataWf);
+        return new ConstraintDataWF(spec, state, isComplete, dataWf);
     }
 
     @Override public LabelOrder<ITerm> getLabelOrder(IRelation<EdgeOrData<ITerm>> labelOrd)
@@ -42,7 +43,7 @@ public class ConstraintQueries implements IConstraintQueries {
     }
 
     @Override public DataLeq<ITerm> getDataEquiv(Rule dataLeq) {
-        return new ConstraintDataLeq(spec, state, completeness, dataLeq);
+        return new ConstraintDataLeq(spec, state, isComplete, dataLeq);
     }
 
 }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
@@ -11,6 +11,7 @@ import mb.scopegraph.oopsla20.reference.RelationLabelOrder;
 import mb.scopegraph.regexp.IRegExpMatcher;
 import mb.scopegraph.relations.IRelation;
 import mb.statix.solver.IState;
+import mb.statix.solver.completeness.ICompleteness;
 import mb.statix.solver.query.IConstraintQueries;
 import mb.statix.spec.Rule;
 import mb.statix.spec.Spec;
@@ -19,10 +20,12 @@ public class ConstraintQueries implements IConstraintQueries {
 
     private final Spec spec;
     private final IState.Immutable state;
+    private final ICompleteness.Immutable completeness;
 
-    public ConstraintQueries(Spec spec, IState.Immutable state) {
+    public ConstraintQueries(Spec spec, IState.Immutable state, ICompleteness.Immutable completeness) {
         this.spec = spec;
         this.state = state;
+        this.completeness = completeness;
     }
 
     @Override public LabelWF<ITerm> getLabelWF(IRegExpMatcher<ITerm> pathWf) throws InterruptedException {
@@ -30,7 +33,7 @@ public class ConstraintQueries implements IConstraintQueries {
     }
 
     @Override public DataWF<ITerm> getDataWF(Rule dataWf) {
-        return new ConstraintDataWF(spec, state, dataWf);
+        return new ConstraintDataWF(spec, state, completeness, dataWf);
     }
 
     @Override public LabelOrder<ITerm> getLabelOrder(IRelation<EdgeOrData<ITerm>> labelOrd)
@@ -39,7 +42,7 @@ public class ConstraintQueries implements IConstraintQueries {
     }
 
     @Override public DataLeq<ITerm> getDataEquiv(Rule dataLeq) {
-        return new ConstraintDataLeq(spec, state, dataLeq);
+        return new ConstraintDataLeq(spec, state, completeness, dataLeq);
     }
 
 }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintQueries.java
@@ -11,7 +11,6 @@ import mb.scopegraph.oopsla20.reference.RelationLabelOrder;
 import mb.scopegraph.regexp.IRegExpMatcher;
 import mb.scopegraph.relations.IRelation;
 import mb.statix.solver.IState;
-import mb.statix.solver.completeness.ICompleteness;
 import mb.statix.solver.completeness.IsComplete;
 import mb.statix.solver.query.IConstraintQueries;
 import mb.statix.spec.Rule;


### PR DESCRIPTION
Fixes the issue that this test exposes:

```
resolve {s_data1 s_data2 res}
  new s_data1,
  new s_data2,
  s_data2 -INHERIT-> s_data1,
  lub(s_data1, s_data2) == res

signature
  name-resolution
    labels
      INHERIT

rules
  lub : scope * scope -> list((path * scope))
  lub(s1, s2) = paths :-
    query ()
      filter INHERIT* and { s_super :-
      	query ()
      	  filter INHERIT* and { s_data :- s_data == s_super }
      	  in s2 |-> [_|_]
      }
    in s1 |-> paths.
```

Basically, the issue was that entailment contexts as instantiated by the name resolution algorithm would always consider all critical edges closed, which made nested query in data{wf,leq} invalid. This changes ensures that the `isComplete` predicate from the parent solver is passed to the solver that evaluates the data{wf,leq} conditions.