### PR TITLE
Libstratego lib imports

### DIFF
--- a/nabl2.lang/trans/nabl2/lang/generation/modules/module.str
+++ b/nabl2.lang/trans/nabl2/lang/generation/modules/module.str
@@ -14,6 +14,7 @@ rules
       module-str
     with
       import-str := Imports([
+        Import("libstratego-lib"),
         Import("signatures/nabl2/shared/-"),
         Import("signatures/nabl2/shared/common/-"),
         Import("signatures/nabl2/shared/constraints/-"),

--- a/nabl2.runtime/trans/nabl2/api.str
+++ b/nabl2.runtime/trans/nabl2/api.str
@@ -1,6 +1,9 @@
 module nabl2/api
 
 imports
+  libstratego-lib
+
+imports
 
   pp/nabl2/API-pp
 

--- a/nabl2.runtime/trans/nabl2/runtime.str
+++ b/nabl2.runtime/trans/nabl2/runtime.str
@@ -1,6 +1,9 @@
 module nabl2/runtime
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/shared
   nabl2/runtime/main

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/constraint-compat.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/constraint-compat.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/constraint-compat
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/analysis/constraint
 

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/debug.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/debug.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/debug
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/runtime/analysis/dot
 

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/dot.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/dot.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/dot
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/nabl2/runtime/analysis/Debug-sig
   nabl2/runtime/pp

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/generation.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/generation.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/generation
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/api
 

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/log.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/log.str
@@ -1,5 +1,8 @@
 module nabl2/runtime/analysis/log 
 
+imports
+  libstratego-lib
+
 rules
 
   nabl2--collection-info-msg(|msg) =

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/main.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/main.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/main
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/api
  

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/query.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/query.str
@@ -1,5 +1,8 @@
 module nabl2/runtime/analysis/query
 
+imports
+  libstratego-lib
+
 // forward to new location
 
 imports

--- a/nabl2.runtime/trans/nabl2/runtime/analysis/signatures.str
+++ b/nabl2.runtime/trans/nabl2/runtime/analysis/signatures.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/analysis/signatures
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/nabl2/shared/common/-
   signatures/nabl2/shared/constraints/-

--- a/nabl2.runtime/trans/nabl2/runtime/completion.str
+++ b/nabl2.runtime/trans/nabl2/runtime/completion.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/completion
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/shared/completion
 

--- a/nabl2.runtime/trans/nabl2/runtime/editor/menus.str
+++ b/nabl2.runtime/trans/nabl2/runtime/editor/menus.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/editor/menus
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/runtime/analysis/-
   nabl2/runtime/prelude/-

--- a/nabl2.runtime/trans/nabl2/runtime/editor/services.str
+++ b/nabl2.runtime/trans/nabl2/runtime/editor/services.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/editor/services
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/term/annotation
   libspoofax/editor/resolution

--- a/nabl2.runtime/trans/nabl2/runtime/main.str
+++ b/nabl2.runtime/trans/nabl2/runtime/main.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/main
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/shared/main
 

--- a/nabl2.runtime/trans/nabl2/runtime/pp.str
+++ b/nabl2.runtime/trans/nabl2/runtime/pp.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/pp
 
 imports
+  libstratego-lib
+
+imports
 
   libstratego-gpp
 

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/bag.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/bag.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/prelude/bag
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/runtime/prelude/map
 

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/base.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/base.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/prelude/base
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/term/annotation
 

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/list.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/list.str
@@ -1,5 +1,8 @@
 module nabl2/runtime/prelude/list
 
+imports
+  libstratego-lib
+
 strategies
   
   // n-ary zip 

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/map.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/map.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/prelude/map
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/runtime/prelude/base
 

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/prelude.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/prelude.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/prelude/prelude
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/runtime/prelude/base
   nabl2/runtime/prelude/list

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/set.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/set.str
@@ -1,5 +1,8 @@
 module nabl2/runtime/prelude/set
 
+imports
+  libstratego-lib
+
 strategies
   
   nabl2--dups = nabl2--dups(eq)

--- a/nabl2.runtime/trans/nabl2/runtime/prelude/time.str
+++ b/nabl2.runtime/trans/nabl2/runtime/prelude/time.str
@@ -1,5 +1,8 @@
 module nabl2/runtime/prelude/time
 
+imports
+  libstratego-lib
+
 rules
 
   cputime = prim("SSL_cputime")

--- a/nabl2.runtime/trans/nabl2/runtime/transform/explicit-types.str
+++ b/nabl2.runtime/trans/nabl2/runtime/transform/explicit-types.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/transform/explicit-types
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/term/annotation
 

--- a/nabl2.runtime/trans/nabl2/runtime/transform/query.str
+++ b/nabl2.runtime/trans/nabl2/runtime/transform/query.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/transform/query 
 
 imports
+  libstratego-lib
+
+imports
 
 
   signatures/nabl2/shared/common/-

--- a/nabl2.runtime/trans/nabl2/runtime/transform/renaming.str
+++ b/nabl2.runtime/trans/nabl2/runtime/transform/renaming.str
@@ -1,6 +1,9 @@
 module nabl2/runtime/transform/renaming
 
 imports
+  libstratego-lib
+
+imports
   signatures/-
   signatures/nabl2/shared/common/-
   signatures/nabl2/runtime/common/-

--- a/nabl2.shared/trans/nabl2/shared.str
+++ b/nabl2.shared/trans/nabl2/shared.str
@@ -1,5 +1,8 @@
 module nabl2/shared
 
 imports
+  libstratego-lib
+
+imports
 
   nabl2/shared/main

--- a/nabl2.shared/trans/nabl2/shared/ast.str
+++ b/nabl2.shared/trans/nabl2/shared/ast.str
@@ -1,6 +1,9 @@
 module nabl2/shared/ast
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/term/origin
   

--- a/nabl2.shared/trans/nabl2/shared/completion.str
+++ b/nabl2.shared/trans/nabl2/shared/completion.str
@@ -1,6 +1,9 @@
 module nabl2/shared/completion
 
 imports
+  libstratego-lib
+
+imports
 
   completion/nabl2/shared/-
  

--- a/nabl2.shared/trans/nabl2/shared/constraints.str
+++ b/nabl2.shared/trans/nabl2/shared/constraints.str
@@ -1,6 +1,9 @@
 module nabl2/shared/common/constraints
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/nabl2/shared/constraints/-
 

--- a/nabl2.shared/trans/nabl2/shared/fresh.str
+++ b/nabl2.shared/trans/nabl2/shared/fresh.str
@@ -1,5 +1,8 @@
 module nabl2/shared/fresh
 
+imports
+  libstratego-lib
+
 rules
 
   nabl2--with-fresh(s) = nabl2--with-fresh(!"", s)

--- a/nabl2.shared/trans/nabl2/shared/main.str
+++ b/nabl2.shared/trans/nabl2/shared/main.str
@@ -1,6 +1,9 @@
 module nabl2/shared/main
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/nabl2/shared/-
   pp/nabl2/shared/-

--- a/nabl2.shared/trans/nabl2/shared/messages.str
+++ b/nabl2.shared/trans/nabl2/shared/messages.str
@@ -1,6 +1,9 @@
 module nabl2/shared/common/messages
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/nabl2/shared/common/-
 

--- a/nabl2.shared/trans/nabl2/shared/pp.str
+++ b/nabl2.shared/trans/nabl2/shared/pp.str
@@ -1,6 +1,9 @@
 module nabl2/shared/common/pp
 
 imports
+  libstratego-lib
+
+imports
 
   libstratego-gpp
 

--- a/nabl2.shared/trans/nabl2/shared/vars.str
+++ b/nabl2.shared/trans/nabl2/shared/vars.str
@@ -1,6 +1,9 @@
 module nabl2/shared/common/vars
 
 imports
+  libstratego-lib
+
+imports
 
   pp/nabl2/shared/common/-
   completion/nabl2/shared/common/-

--- a/org.metaborg.meta.lang.nabl/trans/generation/main.str
+++ b/org.metaborg.meta.lang.nabl/trans/generation/main.str
@@ -41,8 +41,9 @@ rules // modules
     ; i'*   := <map(try(import-to-str))> i*
     with
        <fetch(?ImportWildcard(<string-ends-with(|"/nabl")>))> i*
-     ; lib* := []
-    <+ lib* := [ ImportWildcard("runtime/nabl")
+     ; lib* := [ Import("libstratego-lib") ]
+    <+ lib* := [ Import("libstratego-lib")
+               , ImportWildcard("runtime/nabl")
                , ImportWildcard("runtime/task")
                , ImportWildcard("runtime/properties")
                , ImportWildcard("runtime/types")

--- a/statix.runtime/trans/injections/statix/API-injections.str
+++ b/statix.runtime/trans/injections/statix/API-injections.str
@@ -1,5 +1,8 @@
 module injections/statix/API-injections
 
+imports
+  libstratego-lib
+
 // hand-written injections file for projects importing API.sdf3 and using the
 // SDF3-to-Statix signature generator.
 

--- a/statix.runtime/trans/statix/api.str
+++ b/statix.runtime/trans/statix/api.str
@@ -1,6 +1,9 @@
 module statix/api
 
 imports
+  libstratego-lib
+
+imports
 
   signatures/statix/-
   injections/statix/-

--- a/statix.runtime/trans/statix/runtime/ast.str
+++ b/statix.runtime/trans/statix/runtime/ast.str
@@ -1,6 +1,9 @@
 module statix/runtime/ast
 
 imports
+  libstratego-lib
+
+imports
 
 signature
   constructors

--- a/statix.runtime/trans/statix/runtime/constraints.str
+++ b/statix.runtime/trans/statix/runtime/constraints.str
@@ -1,5 +1,8 @@
 module statix/runtime/constraints
 
+imports
+  libstratego-lib
+
 // Constraint duplicates from statix.lang
 
 imports

--- a/statix.runtime/trans/statix/runtime/menus.str
+++ b/statix.runtime/trans/statix/runtime/menus.str
@@ -1,6 +1,9 @@
 module statix/runtime/menus
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/analysis/constraint
 

--- a/statix.runtime/trans/statix/runtime/pp.str
+++ b/statix.runtime/trans/statix/runtime/pp.str
@@ -1,6 +1,9 @@
 module statix/runtime/pp
 
 imports
+  libstratego-lib
+
+imports
 
   libstratego-gpp
   libspoofax/sdf/pp

--- a/statix.runtime/trans/statix/runtime/services.str
+++ b/statix.runtime/trans/statix/runtime/services.str
@@ -1,6 +1,9 @@
 module statix/runtime/services
 
 imports
+  libstratego-lib
+
+imports
 
   libspoofax/analysis/constraint
 

--- a/statix.runtime/trans/statix/runtime/terms.str
+++ b/statix.runtime/trans/statix/runtime/terms.str
@@ -1,5 +1,8 @@
 module statix/runtime/terms
 
+imports
+  libstratego-lib
+
 // Term duplicates from statix.lang
 
 signature


### PR DESCRIPTION
I want to make these imports to the standard library required in Stratego 2. It's a good idea in general to have them already in your Stratego 1 files for ease of migration. This PR adds them to runtime/shared Stratego files that are imported by users of Statix/NaBL2, and adds them to generated Stratego files by NaBL/NaBL2. 