### PR TITLE
Allow escaped characters in templates (messages)

### DIFF
--- a/statix.lang/syntax/statix/lang/Core.sdf3
+++ b/statix.lang/syntax/statix/lang/Core.sdf3
@@ -433,7 +433,7 @@ lexical syntax
 
   MessageChars = MessageChar+
   MessageChar  = ~[\[\]\\\t\r\n]
-  MessageChar  = "\\[" | "\\]" | "\\\\"
+  MessageChar  = "\\[" | "\\]" | "\\n" | "\\r" | "\\t" | "\\\\"
 
 lexical restrictions
 

--- a/statix.test/base/messages.spt
+++ b/statix.test/base/messages.spt
@@ -2,6 +2,18 @@ module base/messages
 
 language StatixLang
 
+test newline in template message [[
+  resolve false | error $[hello\nworld!]
+]] parse succeeds
+
+test tab in template message [[
+  resolve false | error $[hello\tworld!]
+]] parse succeeds
+
+test carriage return in template message [[
+  resolve false | error $[hello\rworld!]
+]] parse succeeds
+
 test string error on false [[
   resolve false | error "message"
 ]] analysis succeeds


### PR DESCRIPTION
Allow escaped characters (`\n`, `\t`, `\r`) in templates (i.e. notes, warnings and errors). Also adds some syntax tests to test this.
Tested with my own project, it seems to work.

I did not change any code generation, so if there is any code generation then it should be checked if that still works correctly.

Resolves #83