### PR TITLE
Replace Cases with enum Tag and switch statements

### DIFF
--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IApplTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IApplTerm.java
@@ -12,4 +12,7 @@ public interface IApplTerm extends ITerm {
 
     @Override IApplTerm withAttachments(IAttachments value);
 
+    @Override default Tag termTag() {
+        return Tag.IApplTerm;
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IBlobTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IBlobTerm.java
@@ -7,4 +7,8 @@ public interface IBlobTerm extends ITerm {
     @Override
     IBlobTerm withAttachments(IAttachments value);
 
+    @Override default Tag termTag() {
+        return Tag.IBlobTerm;
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IConsTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IConsTerm.java
@@ -9,4 +9,7 @@ public interface IConsTerm extends IListTerm {
     @Override
     IConsTerm withAttachments(IAttachments value);
 
+    @Override default Tag listTermTag() {
+        return Tag.IConsTerm;
+    }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IConsTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IConsTerm.java
@@ -9,7 +9,11 @@ public interface IConsTerm extends IListTerm {
     @Override
     IConsTerm withAttachments(IAttachments value);
 
-    @Override default Tag listTermTag() {
-        return Tag.IConsTerm;
+    @Override default ITerm.Tag termTag() {
+        return ITerm.Tag.IConsTerm;
+    }
+
+    @Override default IListTerm.Tag listTermTag() {
+        return IListTerm.Tag.IConsTerm;
     }
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IIntTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IIntTerm.java
@@ -7,4 +7,8 @@ public interface IIntTerm extends ITerm {
     @Override
     IIntTerm withAttachments(IAttachments value);
 
+    @Override default Tag termTag() {
+        return Tag.IIntTerm;
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IListTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IListTerm.java
@@ -45,4 +45,16 @@ public interface IListTerm extends ITerm {
     @Override
     IListTerm withAttachments(IAttachments value);
 
+    @Override default ITerm.Tag termTag() {
+        return ITerm.Tag.IListTerm;
+    }
+
+    Tag listTermTag();
+
+    enum Tag {
+        IConsTerm,
+        INilTerm,
+        ITermVar
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IListTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IListTerm.java
@@ -45,10 +45,6 @@ public interface IListTerm extends ITerm {
     @Override
     IListTerm withAttachments(IAttachments value);
 
-    @Override default ITerm.Tag termTag() {
-        return ITerm.Tag.IListTerm;
-    }
-
     Tag listTermTag();
 
     enum Tag {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/INilTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/INilTerm.java
@@ -5,8 +5,12 @@ public interface INilTerm extends IListTerm {
     @Override
     INilTerm withAttachments(IAttachments value);
 
-    @Override default Tag listTermTag() {
-        return Tag.INilTerm;
+    @Override default ITerm.Tag termTag() {
+        return ITerm.Tag.INilTerm;
+    }
+
+    @Override default IListTerm.Tag listTermTag() {
+        return IListTerm.Tag.INilTerm;
     }
 
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/INilTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/INilTerm.java
@@ -5,4 +5,8 @@ public interface INilTerm extends IListTerm {
     @Override
     INilTerm withAttachments(IAttachments value);
 
+    @Override default Tag listTermTag() {
+        return Tag.INilTerm;
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/IStringTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/IStringTerm.java
@@ -7,4 +7,8 @@ public interface IStringTerm extends ITerm {
     @Override
     IStringTerm withAttachments(IAttachments value);
 
+    @Override default Tag termTag() {
+        return Tag.IStringTerm;
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/ITerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/ITerm.java
@@ -64,4 +64,15 @@ public interface ITerm {
 
     }
 
+    Tag termTag();
+
+    enum Tag {
+        IApplTerm,
+        IListTerm,
+        IStringTerm,
+        IIntTerm,
+        IBlobTerm,
+        ITermVar,
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/ITerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/ITerm.java
@@ -30,13 +30,13 @@ public interface ITerm {
 
         T caseAppl(IApplTerm appl);
 
-        T caseList(IListTerm cons);
+        T caseList(IListTerm list);
 
         T caseString(IStringTerm string);
 
         T caseInt(IIntTerm integer);
 
-        T caseBlob(IBlobTerm integer);
+        T caseBlob(IBlobTerm blob);
 
         T caseVar(ITermVar var);
 
@@ -48,13 +48,13 @@ public interface ITerm {
 
         T caseAppl(IApplTerm appl) throws E;
 
-        T caseList(IListTerm cons) throws E;
+        T caseList(IListTerm list) throws E;
 
         T caseString(IStringTerm string) throws E;
 
         T caseInt(IIntTerm integer) throws E;
 
-        T caseBlob(IBlobTerm integer) throws E;
+        T caseBlob(IBlobTerm blob) throws E;
 
         T caseVar(ITermVar var) throws E;
 
@@ -68,7 +68,8 @@ public interface ITerm {
 
     enum Tag {
         IApplTerm,
-        IListTerm,
+        IConsTerm,
+        INilTerm,
         IStringTerm,
         IIntTerm,
         IBlobTerm,

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/ITermVar.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/ITermVar.java
@@ -19,4 +19,12 @@ public interface ITermVar extends ITerm, IListTerm, Comparable<ITermVar> {
         return c;
     }
 
+    @Override default ITerm.Tag termTag() {
+        return ITerm.Tag.ITermVar;
+    }
+
+    @Override default IListTerm.Tag listTermTag() {
+        return IListTerm.Tag.ITermVar;
+    }
+
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/ListTerms.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/ListTerms.java
@@ -174,8 +174,20 @@ public class ListTerms {
     }
 
     public static String toString(IListTerm list) {
-        return list
-                .match(cases(cons -> toStringTail(cons.getHead(), cons.getTail()), nil -> "[]", var -> var.toString()));
+        switch(list.listTermTag()) {
+            case IConsTerm: {
+                IConsTerm cons = (IConsTerm) list;
+                return toStringTail(cons.getHead(), cons.getTail());
+            }
+            case INilTerm: {
+                return "[]";
+            }
+            case ITermVar: {
+                return list.toString();
+            }
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for IListTerm subclass/tag");
     }
 
     private static String toStringTail(ITerm head, IListTerm tail) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/build/AConsTerm.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/build/AConsTerm.java
@@ -8,13 +8,14 @@ import org.immutables.serial.Serial;
 import org.immutables.value.Value;
 import org.metaborg.util.collection.CapsuleUtil;
 import org.metaborg.util.functions.Action1;
+import org.metaborg.util.functions.Function2;
 
 import io.usethesource.capsule.Set;
 import mb.nabl2.terms.IConsTerm;
 import mb.nabl2.terms.IListTerm;
+import mb.nabl2.terms.INilTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
-import mb.nabl2.terms.ListTerms;
 
 @Value.Immutable(lazyhash = false)
 @Serial.Version(value = 42L)
@@ -94,23 +95,30 @@ abstract class AConsTerm extends AbstractTerm implements IConsTerm {
         StringBuilder sb = new StringBuilder();
         sb.append("[");
         sb.append(getHead());
-        getTail().match(ListTerms.casesFix(
-        // @formatter:off
-            (f,cons) -> {
-                sb.append(",");
-                sb.append(cons.getHead());
-                return cons.getTail().match(f);
-            },
-            (f,nil) -> unit,
-            (f,var) -> {
-                sb.append("|");
-                sb.append(var);
-                return unit;
-            }
-            // @formatter:on
-        ));
+        toString(getTail(), sb);
         sb.append("]");
         return sb.toString();
+    }
+
+    private static void toString(IListTerm subj, StringBuilder sb) {
+        switch(subj.listTermTag()) {
+            case IConsTerm: { IConsTerm cons = (IConsTerm) subj;
+                sb.append(",");
+                sb.append(cons.getHead());
+                toString(cons.getTail(), sb);
+                break;
+            }
+
+            case INilTerm: {
+                break;
+            }
+
+            case ITermVar: { ITermVar var = (ITermVar) subj;
+                sb.append("|");
+                sb.append(var);
+                break;
+            }
+        }
     }
 
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/build/ListTermIterator.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/build/ListTermIterator.java
@@ -3,9 +3,13 @@ package mb.nabl2.terms.build;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.metaborg.util.functions.Function1;
+
+import mb.nabl2.terms.IConsTerm;
 import mb.nabl2.terms.IListTerm;
+import mb.nabl2.terms.INilTerm;
 import mb.nabl2.terms.ITerm;
-import mb.nabl2.terms.ListTerms;
+import mb.nabl2.terms.ITermVar;
 
 public class ListTermIterator implements Iterator<ITerm> {
 
@@ -16,20 +20,42 @@ public class ListTermIterator implements Iterator<ITerm> {
     }
 
     @Override public boolean hasNext() {
-        return current.match(ListTerms.cases(cons -> true, nil -> false, var -> {
-            throw new IllegalStateException("Cannot iterate over a non-ground list.");
-        }));
+        IListTerm subj = current;
+        switch(subj.listTermTag()) {
+            case IConsTerm: {
+                return true;
+            }
+
+            case INilTerm: {
+                return false;
+            }
+
+            case ITermVar: {
+                throw new IllegalStateException("Cannot iterate over a non-ground list.");
+            }
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for IListTerm subclass/tag");
     }
 
     @Override public ITerm next() {
-        return current.match(ListTerms.cases(cons -> {
-            current = cons.getTail();
-            return cons.getHead();
-        }, nil -> {
-            throw new NoSuchElementException();
-        }, var -> {
-            throw new IllegalStateException("Cannot iterate over a non-ground list.");
-        }));
+        IListTerm subj = current;
+        switch(subj.listTermTag()) {
+            case IConsTerm: { IConsTerm cons = (IConsTerm) subj;
+                current = cons.getTail();
+                return cons.getHead();
+            }
+
+            case INilTerm: {
+                throw new NoSuchElementException();
+            }
+
+            case ITermVar: {
+                throw new IllegalStateException("Cannot iterate over a non-ground list.");
+            }
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for IListTerm subclass/tag");
     }
 
 }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/CheckedTermMatch.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/CheckedTermMatch.java
@@ -1,5 +1,6 @@
 package mb.nabl2.terms.matching;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -9,9 +10,8 @@ import org.metaborg.util.functions.CheckedFunction2;
 import org.metaborg.util.functions.CheckedFunction3;
 import org.metaborg.util.functions.CheckedFunction4;
 
-import com.google.common.collect.Lists;
-
 import mb.nabl2.terms.IApplTerm;
+import mb.nabl2.terms.IBlobTerm;
 import mb.nabl2.terms.IConsTerm;
 import mb.nabl2.terms.IIntTerm;
 import mb.nabl2.terms.IListTerm;
@@ -20,7 +20,6 @@ import mb.nabl2.terms.IStringTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
 import mb.nabl2.terms.ListTerms;
-import mb.nabl2.terms.Terms;
 import mb.nabl2.terms.unification.Unifiers;
 import mb.nabl2.terms.unification.u.IUnifier;
 
@@ -33,35 +32,48 @@ public class CheckedTermMatch {
         // term
 
         public <E extends Throwable> ICheckedMatcher<ITerm, E> term() {
-            return (term, unifier) -> Optional.of(term);
+            return (term, unifier) -> {
+                return Optional.of(term);
+            };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> term(CheckedFunction1<? super ITerm, R, ? extends E> f) {
-            return (term, unifier) -> Optional.of(f.apply(term));
+            return (term, unifier) -> {
+                return Optional.of(f.apply(term));
+            };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> term(ITerm.CheckedCases<Optional<R>, E> cases) {
-            return (term, unifier) -> unifier.findTerm(term).matchOrThrow(cases);
+            return (term, unifier) -> {
+                return unifier.findTerm(term).matchOrThrow(cases);
+            };
         }
 
         // appl
 
         public <R, E extends Throwable> ICheckedMatcher<R, E>
                 appl(CheckedFunction1<? super IApplTerm, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(appl -> Optional.of(f.apply(appl)), this::empty,
-                            this::empty, this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    return Optional.of(f.apply((IApplTerm) subj));
+                }
+                return Optional.empty();
+            };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> appl0(String op,
                 CheckedFunction1<? super IApplTerm, R, ? extends E> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(Terms.<Optional<R>, E>checkedCases(appl -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 0 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
                     return Optional.of(f.apply(appl));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                }
+                return Optional.empty();
             };
         }
 
@@ -69,7 +81,9 @@ public class CheckedTermMatch {
                 ICheckedMatcher<? extends T, ? extends E> m,
                 CheckedFunction2<? super IApplTerm, ? super T, R, ? extends E> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(Terms.<Optional<R>, E>checkedCases(appl -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 1 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -79,7 +93,8 @@ public class CheckedTermMatch {
                     }
                     T t = o1.get();
                     return Optional.of(f.apply(appl, t));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                }
+                return Optional.empty();
             };
         }
 
@@ -87,7 +102,9 @@ public class CheckedTermMatch {
                 ICheckedMatcher<? extends T1, ? extends E> m1, ICheckedMatcher<? extends T2, ? extends E> m2,
                 CheckedFunction3<? super IApplTerm, ? super T1, ? super T2, R, ? extends E> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(Terms.<Optional<R>, E>checkedCases(appl -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 2 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -102,7 +119,8 @@ public class CheckedTermMatch {
                     }
                     T2 t2 = o2.get();
                     return Optional.of(f.apply(appl, t1, t2));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                }
+                return Optional.empty();
             };
         }
 
@@ -111,7 +129,9 @@ public class CheckedTermMatch {
                 ICheckedMatcher<? extends T3, ? extends E> m3,
                 CheckedFunction4<? super IApplTerm, ? super T1, ? super T2, ? super T3, R, ? extends E> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(Terms.<Optional<R>, E>checkedCases(appl -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 3 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -131,7 +151,8 @@ public class CheckedTermMatch {
                     }
                     T3 t3 = o3.get();
                     return Optional.of(f.apply(appl, t1, t2, t3));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                }
+                return Optional.empty();
             };
         }
 
@@ -139,26 +160,34 @@ public class CheckedTermMatch {
 
         public <R, E extends Throwable> ICheckedMatcher<R, E>
                 list(CheckedFunction1<? super IListTerm, R, ? extends E> f) {
-            final CheckedFunction1<? super IListTerm, Optional<R>, E> g = list -> Optional.of(f.apply(list));
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(
-                        Terms.<Optional<R>, E>checkedCases(this::empty, g, this::empty, this::empty, this::empty, g));
+                final ITerm subj = unifier.findTerm(term);
+                if(subj instanceof IListTerm) {
+                    IListTerm list = (IListTerm) subj;
+                    return Optional.of(f.apply(list));
+                }
+                return Optional.empty();
             };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> list(IListTerm.CheckedCases<Optional<R>, E> cases) {
-            final CheckedFunction1<? super IListTerm, Optional<R>, E> g = list -> list.matchOrThrow(cases);
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(
-                        Terms.<Optional<R>, E>checkedCases(this::empty, g, this::empty, this::empty, this::empty, g));
+                final ITerm subj = unifier.findTerm(term);
+                if(subj instanceof IListTerm) {
+                    IListTerm list = (IListTerm) subj;
+                    return list.matchOrThrow(cases);
+                }
+                return Optional.empty();
             };
         }
 
         public <T, R, E extends Throwable> ICheckedMatcher<R, E> listElems(ICheckedMatcher<? extends T, ? extends E> m,
                 CheckedFunction2<? super IListTerm, Iterable<T>, R, ? extends E> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, list -> {
-                    List<T> ts = Lists.newArrayList();
+                final ITerm subj = unifier.findTerm(term);
+                if(subj instanceof IListTerm && subj.termTag() != ITerm.Tag.ITermVar) {
+                    IListTerm list = (IListTerm) subj;
+                    List<T> ts = new ArrayList<>();
                     for(ITerm t : ListTerms.iterable(list)) {
                         Optional<? extends T> o = m.matchOrThrow(t, unifier);
                         if(!o.isPresent()) {
@@ -167,55 +196,74 @@ public class CheckedTermMatch {
                         ts.add(o.get());
                     }
                     return Optional.of(f.apply(list, ts));
-                }, this::empty, this::empty, this::empty, this::empty));
+                }
+                return Optional.empty();
             };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E>
                 cons(CheckedFunction1<? super IConsTerm, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, list -> {
-                        return list.matchOrThrow(ListTerms.<Optional<R>, E>checkedCases(
-                                cons -> Optional.of(f.apply(cons)), nil -> Optional.empty(), var -> Optional.empty()));
-                    }, this::empty, this::empty, this::empty, this::empty));
-
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IConsTerm) {
+                    IConsTerm cons = (IConsTerm) subj;
+                    return Optional.of(f.apply(cons));
+                }
+                return Optional.empty();
+            };
         }
 
         public <R, E extends Throwable> ICheckedMatcher<R, E>
                 nil(CheckedFunction1<? super INilTerm, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, list -> {
-                        return list.matchOrThrow(ListTerms.<Optional<R>, E>checkedCases(cons -> Optional.empty(),
-                                nil -> Optional.of(f.apply(nil)), var -> Optional.empty()));
-                    }, this::empty, this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.INilTerm) {
+                    INilTerm nil = (INilTerm) subj;
+                    return Optional.of(f.apply(nil));
+                }
+                return Optional.empty();
+            };
 
         }
 
         // integer
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> integer(CheckedFunction1<IIntTerm, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, this::empty, this::empty,
-                            string -> Optional.of(f.apply(string)), this::empty, this::empty));
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IIntTerm) {
+                    IIntTerm integer = (IIntTerm) subj;
+                    return Optional.of(f.apply(integer));
+                }
+                return Optional.empty();
+            };
         }
 
         // string
 
         public <R, E extends Throwable> ICheckedMatcher<R, E> string(CheckedFunction1<IStringTerm, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, this::empty,
-                            string -> Optional.of(f.apply(string)), this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IStringTerm) {
+                    IStringTerm string = (IStringTerm) subj;
+                    return Optional.of(f.apply(string));
+                }
+                return Optional.empty();
+            };
         }
 
         // var
 
         public <R, E extends Throwable> ICheckedMatcher<R, E>
                 var(CheckedFunction1<? super ITermVar, R, ? extends E> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .matchOrThrow(Terms.<Optional<R>, E>checkedCases(this::empty, list -> {
-                        return list.matchOrThrow(ListTerms.<Optional<R>, E>checkedCases(cons -> Optional.empty(),
-                                nil -> Optional.empty(), var -> Optional.of(f.apply(var))));
-                    }, this::empty, this::empty, this::empty, var -> Optional.of(f.apply(var))));
+            return (term, unifier) -> {
+                final ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.ITermVar) {
+                    ITermVar var = (ITermVar) subj;
+                    return Optional.of(f.apply(var));
+                }
+                return Optional.empty();
+            };
         }
 
         // cases
@@ -235,10 +283,6 @@ public class CheckedTermMatch {
 
         // util
 
-        private <T> Optional<T> empty(@SuppressWarnings("unused") ITerm term) {
-            return Optional.empty();
-        }
-
     }
 
     @FunctionalInterface
@@ -251,11 +295,15 @@ public class CheckedTermMatch {
         }
 
         default <R> ICheckedMatcher<R, E> map(Function<T, R> fun) {
-            return (term, unifier) -> this.matchOrThrow(term, unifier).<R>map(fun);
+            return (term, unifier) -> {
+                return this.matchOrThrow(term, unifier).<R>map(fun);
+            };
         }
 
         default <R> ICheckedMatcher<R, E> flatMap(Function<T, Optional<R>> fun) {
-            return (term, unifier) -> this.matchOrThrow(term, unifier).<R>flatMap(fun);
+            return (term, unifier) -> {
+                return this.matchOrThrow(term, unifier).<R>flatMap(fun);
+            };
         }
 
     }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/ConsPattern.java
@@ -1,8 +1,5 @@
 package mb.nabl2.terms.matching;
 
-import static mb.nabl2.terms.build.TermBuild.B;
-import static mb.nabl2.terms.matching.TermMatch.M;
-
 import java.util.Objects;
 import java.util.Optional;
 
@@ -14,13 +11,17 @@ import org.metaborg.util.iterators.Iterables2;
 
 import io.usethesource.capsule.Set;
 import mb.nabl2.terms.IAttachments;
+import mb.nabl2.terms.IConsTerm;
 import mb.nabl2.terms.IListTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
-import mb.nabl2.terms.ListTerms;
 import mb.nabl2.terms.substitution.IRenaming;
 import mb.nabl2.terms.substitution.ISubstitution;
+import mb.nabl2.terms.unification.Unifiers;
 import mb.nabl2.terms.unification.u.IUnifier;
+import mb.nabl2.terms.unification.ud.IUniDisunifier;
+
+import static mb.nabl2.terms.build.TermBuild.B;
 
 class ConsPattern extends Pattern {
     private static final long serialVersionUID = 1L;
@@ -55,21 +56,31 @@ class ConsPattern extends Pattern {
 
     @Override protected boolean matchTerm(ITerm term,
             ISubstitution.Transient subst, IUnifier.Immutable unifier, Eqs eqs) {
-        // @formatter:off
-        return M.list(listTerm -> {
-            return listTerm.match(ListTerms.<Boolean>cases()
-                .cons(consTerm -> {
+        ITerm subj = Unifiers.Immutable.of().findTerm(unifier.findTerm(term));
+        if(subj instanceof IListTerm) {
+            final IListTerm list = (IListTerm) subj;
+            switch(list.listTermTag()) {
+                case IConsTerm: {
+                    IConsTerm consTerm = (IConsTerm) list;
                     return matchTerms(Iterables2.from(head, tail),
-                            Iterables2.from(consTerm.getHead(), consTerm.getTail()), subst, unifier, eqs);
-                }).var(v -> {
-                    eqs.add(v, this);
-                    return true;
-                }).otherwise(t -> {
+                        Iterables2.from(consTerm.getHead(), consTerm.getTail()), subst, unifier,
+                        eqs);
+                }
+
+                case INilTerm: {
                     return false;
-                })
-            );
-        }).match(unifier.findTerm(term)).orElse(false);
-        // @formatter:on
+                }
+
+                case ITermVar: {
+                    eqs.add((ITermVar) list, this);
+                    return true;
+                }
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IListTerm subclass/tag");
+        } else {
+            return false;
+        }
     }
 
     @Override public ConsPattern apply(IRenaming subst) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/IntPattern.java
@@ -11,7 +11,12 @@ import org.metaborg.util.functions.Function0;
 import org.metaborg.util.functions.Function1;
 
 import io.usethesource.capsule.Set;
+import mb.nabl2.terms.IApplTerm;
 import mb.nabl2.terms.IAttachments;
+import mb.nabl2.terms.IBlobTerm;
+import mb.nabl2.terms.IIntTerm;
+import mb.nabl2.terms.IListTerm;
+import mb.nabl2.terms.IStringTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
 import mb.nabl2.terms.Terms;
@@ -43,18 +48,28 @@ class IntPattern extends Pattern {
 
     @Override protected boolean matchTerm(ITerm term, ISubstitution.Transient subst, IUnifier.Immutable unifier,
             Eqs eqs) {
-        // @formatter:off
-        return unifier.findTerm(term).match(Terms.<Boolean>cases()
-            .integer(intTerm -> {
+        final IntPattern pattern = this;
+        ITerm subj = unifier.findTerm(term);
+        switch(subj.termTag()) {
+            case IIntTerm: { IIntTerm intTerm = (IIntTerm) subj;
                 return intTerm.getValue() == value;
-            }).var(v -> {
-                eqs.add(v, this);
+            }
+
+            case ITermVar: { ITermVar v = (ITermVar) subj;
+                eqs.add(v, pattern);
                 return true;
-            }).otherwise(t -> {
+            }
+
+            case IApplTerm:
+            case IConsTerm:
+            case INilTerm:
+            case IStringTerm:
+            case IBlobTerm: {
                 return false;
-            })
-        );
-        // @formatter:on
+            }
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for ITerm subclass/tag");
     }
 
     @Override public IntPattern apply(IRenaming subst) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/NilPattern.java
@@ -1,23 +1,28 @@
 package mb.nabl2.terms.matching;
 
-import static mb.nabl2.terms.build.TermBuild.B;
-import static mb.nabl2.terms.matching.TermMatch.M;
-
 import java.util.Optional;
 
 import org.metaborg.util.collection.CapsuleUtil;
 import org.metaborg.util.functions.Action2;
 import org.metaborg.util.functions.Function0;
 import org.metaborg.util.functions.Function1;
+import org.metaborg.util.iterators.Iterables2;
 
 import io.usethesource.capsule.Set;
 import mb.nabl2.terms.IAttachments;
+import mb.nabl2.terms.IConsTerm;
+import mb.nabl2.terms.IListTerm;
+import mb.nabl2.terms.INilTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
 import mb.nabl2.terms.ListTerms;
 import mb.nabl2.terms.substitution.IRenaming;
 import mb.nabl2.terms.substitution.ISubstitution;
+import mb.nabl2.terms.unification.Unifiers;
 import mb.nabl2.terms.unification.u.IUnifier;
+
+import static mb.nabl2.terms.build.TermBuild.B;
+import static mb.nabl2.terms.matching.TermMatch.M;
 
 class NilPattern extends Pattern {
     private static final long serialVersionUID = 1L;
@@ -36,20 +41,28 @@ class NilPattern extends Pattern {
 
     @Override protected boolean matchTerm(ITerm term, ISubstitution.Transient subst, IUnifier.Immutable unifier,
             Eqs eqs) {
-        // @formatter:off
-        return M.list(listTerm -> {
-            return listTerm.match(ListTerms.<Boolean>cases()
-                .nil(nilTerm -> {
-                    return true;
-                }).var(v -> {
-                    eqs.add(v, this);
-                    return true;
-                }).otherwise(t -> {
+        ITerm subj = Unifiers.Immutable.of().findTerm(unifier.findTerm(term));
+        if(subj instanceof IListTerm) {
+            final IListTerm list = (IListTerm) subj;
+            switch(list.listTermTag()) {
+                case IConsTerm: {
                     return false;
-                })
-            );
-        }).match(unifier.findTerm(term)).orElse(false);
-        // @formatter:on
+                }
+
+                case INilTerm: {
+                    return true;
+                }
+
+                case ITermVar: {
+                    eqs.add((ITermVar) list, this);
+                    return true;
+                }
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IListTerm subclass/tag");
+        } else {
+            return false;
+        }
     }
 
     @Override public NilPattern apply(IRenaming subst) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/StringPattern.java
@@ -11,7 +11,12 @@ import org.metaborg.util.functions.Function0;
 import org.metaborg.util.functions.Function1;
 
 import io.usethesource.capsule.Set;
+import mb.nabl2.terms.IApplTerm;
 import mb.nabl2.terms.IAttachments;
+import mb.nabl2.terms.IBlobTerm;
+import mb.nabl2.terms.IIntTerm;
+import mb.nabl2.terms.IListTerm;
+import mb.nabl2.terms.IStringTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
 import mb.nabl2.terms.Terms;
@@ -43,18 +48,28 @@ class StringPattern extends Pattern {
 
     @Override protected boolean matchTerm(ITerm term, ISubstitution.Transient subst, IUnifier.Immutable unifier,
             Eqs eqs) {
-        // @formatter:off
-        return unifier.findTerm(term).match(Terms.<Boolean>cases()
-            .string(stringTerm -> {
+        final StringPattern pattern = this;
+        ITerm subj = unifier.findTerm(term);
+        switch(subj.termTag()) {
+            case IStringTerm: { IStringTerm stringTerm = (IStringTerm) subj;
                 return stringTerm.getValue().equals(value);
-            }).var(v -> {
-                eqs.add(v, this);
+            }
+
+            case ITermVar: { ITermVar v = (ITermVar) subj;
+                eqs.add(v, pattern);
                 return true;
-            }).otherwise(t -> {
+            }
+
+            case IApplTerm:
+            case IConsTerm:
+            case INilTerm:
+            case IIntTerm:
+            case IBlobTerm: {
                 return false;
-            })
-        );
-        // @formatter:on
+            }
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for ITerm subclass/tag");
     }
 
     @Override public StringPattern apply(IRenaming subst) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/matching/TermMatch.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/matching/TermMatch.java
@@ -2,6 +2,7 @@ package mb.nabl2.terms.matching;
 
 import static mb.nabl2.terms.Terms.TUPLE_OP;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -32,7 +33,6 @@ import mb.nabl2.terms.IStringTerm;
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.ITermVar;
 import mb.nabl2.terms.ListTerms;
-import mb.nabl2.terms.Terms;
 import mb.nabl2.terms.unification.Unifiers;
 import mb.nabl2.terms.unification.u.IUnifier;
 
@@ -63,8 +63,15 @@ public class TermMatch {
         // appl
 
         public IMatcher<IApplTerm> appl() {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<IApplTerm>>cases(Optional::of,
-                    this::empty, this::empty, this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
+                    return Optional.of(appl);
+                } else {
+                    return Optional.empty();
+                }
+            };
         }
 
         public <R> IMatcher<R> appl(String op, Function1<? super IApplTerm, R> f) {
@@ -72,23 +79,33 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> appl(Function1<? super IApplTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term)
-                    .match(Terms.<Optional<R>>cases(appl -> Optional.of(f.apply(appl)), this::empty, this::empty,
-                            this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
+                    return Optional.of(f.apply(appl));
+                } else {
+                    return Optional.empty();
+                }
+            };
         }
 
         public IMatcher<IApplTerm> appl0(String op) {
-            return appl0(op, (appl) -> appl);
+            return appl0(op, appl -> appl);
         }
 
         public <R> IMatcher<R> appl0(String op, Function1<? super IApplTerm, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 0 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
                     return Optional.of(f.apply(appl));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -99,12 +116,16 @@ public class TermMatch {
         public <T, R> IMatcher<R> appl1(String op, IMatcher<? extends T> m,
                 Function2<? super IApplTerm, ? super T, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 1 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
                     return m.match(appl.getArgs().get(0), unifier).map(t -> f.apply(appl, t));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -115,14 +136,18 @@ public class TermMatch {
         public <T1, T2, R> IMatcher<R> appl2(String op, IMatcher<? extends T1> m1, IMatcher<? extends T2> m2,
                 Function3<? super IApplTerm, ? super T1, ? super T2, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 2 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
                     Optional<? extends T1> o1 = m1.match(appl.getArgs().get(0), unifier);
                     Optional<? extends T2> o2 = m2.match(appl.getArgs().get(1), unifier);
                     return Optionals.lift(o1, o2, (t1, t2) -> f.apply(appl, t1, t2));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -134,15 +159,20 @@ public class TermMatch {
         public <T1, T2, T3, R> IMatcher<R> appl3(String op, IMatcher<? extends T1> m1, IMatcher<? extends T2> m2,
                 IMatcher<? extends T3> m3, Function4<? super IApplTerm, ? super T1, ? super T2, ? super T3, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 3 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
                     Optional<? extends T1> o1 = m1.match(appl.getArgs().get(0), unifier);
                     Optional<? extends T2> o2 = m2.match(appl.getArgs().get(1), unifier);
                     Optional<? extends T3> o3 = m3.match(appl.getArgs().get(2), unifier);
-                    return Optionals.lift(o1, o2, o3, (t1, t2, t3) -> f.apply(appl, t1, t2, t3));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                    return Optionals.lift(o1, o2, o3,
+                        (t1, t2, t3) -> f.apply(appl, t1, t2, t3));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -155,7 +185,9 @@ public class TermMatch {
                 IMatcher<? extends T3> m3, IMatcher<? extends T4> m4,
                 Function5<? super IApplTerm, ? super T1, ? super T2, ? super T3, ? super T4, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 4 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -163,8 +195,11 @@ public class TermMatch {
                     Optional<? extends T2> o2 = m2.match(appl.getArgs().get(1), unifier);
                     Optional<? extends T3> o3 = m3.match(appl.getArgs().get(2), unifier);
                     Optional<? extends T4> o4 = m4.match(appl.getArgs().get(3), unifier);
-                    return Optionals.lift(o1, o2, o3, o4, (t1, t2, t3, t4) -> f.apply(appl, t1, t2, t3, t4));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                    return Optionals.lift(o1, o2, o3, o4,
+                        (t1, t2, t3, t4) -> f.apply(appl, t1, t2, t3, t4));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -178,7 +213,9 @@ public class TermMatch {
                 IMatcher<? extends T5> m5,
                 Function6<? super IApplTerm, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 5 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -188,8 +225,10 @@ public class TermMatch {
                     Optional<? extends T4> o4 = m4.match(appl.getArgs().get(3), unifier);
                     Optional<? extends T5> o5 = m5.match(appl.getArgs().get(4), unifier);
                     return Optionals.lift(o1, o2, o3, o4, o5,
-                            (t1, t2, t3, t4, t5) -> f.apply(appl, t1, t2, t3, t4, t5));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                        (t1, t2, t3, t4, t5) -> f.apply(appl, t1, t2, t3, t4, t5));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -203,7 +242,9 @@ public class TermMatch {
                 IMatcher<? extends T5> m5, IMatcher<T6> m6,
                 Function7<? super IApplTerm, ? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(appl -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IApplTerm) {
+                    IApplTerm appl = (IApplTerm) subj;
                     if(!(appl.getArity() == 6 && op.equals(appl.getOp()))) {
                         return Optional.empty();
                     }
@@ -214,8 +255,10 @@ public class TermMatch {
                     Optional<? extends T5> o5 = m5.match(appl.getArgs().get(4), unifier);
                     Optional<? extends T6> o6 = m6.match(appl.getArgs().get(5), unifier);
                     return Optionals.lift(o1, o2, o3, o4, o5, o6,
-                            (t1, t2, t3, t4, t5, t6) -> f.apply(appl, t1, t2, t3, t4, t5, t6));
-                }, this::empty, this::empty, this::empty, this::empty, this::empty));
+                        (t1, t2, t3, t4, t5, t6) -> f.apply(appl, t1, t2, t3, t4, t5, t6));
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -285,14 +328,18 @@ public class TermMatch {
         // list
 
         public IMatcher<IListTerm> list() {
-            return list((l) -> l);
+            return list(l -> l);
         }
 
         public <R> IMatcher<R> list(Function1<? super IListTerm, R> f) {
             final Function1<? super IListTerm, ? extends Optional<R>> g = list -> Optional.of(f.apply(list));
             return (term, unifier) -> {
-                return unifier.findTerm(term)
-                        .match(Terms.<Optional<R>>cases(this::empty, g, this::empty, this::empty, this::empty, g));
+                ITerm subj = unifier.findTerm(term);
+                if(subj instanceof IListTerm) {
+                    return g.apply((IListTerm) subj);
+                } else {
+                    return Optional.empty();
+                }
             };
         }
 
@@ -307,34 +354,44 @@ public class TermMatch {
         public <T, R> IMatcher<R> listElems(IMatcher<T> m,
                 Function2<? super IListTerm, ? super ImmutableList<T>, R> f) {
             return (term, unifier) -> {
-                return unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, list -> {
-                    List<Optional<T>> os = Lists.newArrayList();
+                ITerm subj = unifier.findTerm(term);
+                if(subj instanceof IListTerm && subj.termTag() != ITerm.Tag.ITermVar) {
+                    IListTerm list = (IListTerm) subj;
+                    List<Optional<T>> os = new ArrayList<>();
                     for(ITerm t : ListTerms.iterable(list)) {
                         os.add(m.match(t, unifier));
                     }
-                    return Optionals.sequence(os).map(ts -> (R) f.apply(list, ImmutableList.copyOf(ts)));
-                }, this::empty, this::empty, this::empty, this::empty));
+                    return Optionals.sequence(os)
+                        .map(ts -> f.apply(list, ImmutableList.copyOf(ts)));
+                }
+                return Optional.empty();
             };
         }
 
         public <R> IMatcher<R> cons(Function1<? super IConsTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, list -> {
-                return list.match(ListTerms.<Optional<R>>cases(cons -> Optional.of(f.apply(cons)),
-                        nil -> Optional.empty(), var -> Optional.empty()));
-            }, this::empty, this::empty, this::empty, this::empty));
-
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IConsTerm) {
+                    IConsTerm cons = (IConsTerm) subj;
+                    return Optional.of(f.apply(cons));
+                }
+                return Optional.empty();
+            };
         }
 
         public <THd, TTl, R> IMatcher<R> cons(IMatcher<? extends THd> mhd, IMatcher<? extends TTl> mtl,
                 Function3<? super IConsTerm, ? super THd, ? super TTl, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, list -> {
-                return list.match(ListTerms.<Optional<R>>cases(cons -> {
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IConsTerm) {
+                    IConsTerm cons = (IConsTerm) subj;
                     Optional<? extends THd> ohd = mhd.match(cons.getHead(), unifier);
                     Optional<? extends TTl> otl = mtl.match(cons.getTail(), unifier);
-                    return Optionals.lift(ohd, otl, (thd, ttl) -> f.apply(cons, thd, ttl));
-                }, this::empty, this::empty));
-            }, this::empty, this::empty, this::empty, this::empty));
-
+                    return Optionals.lift(ohd, otl,
+                        (thd, ttl) -> f.apply(cons, thd, ttl));
+                }
+                return Optional.empty();
+            };
         }
 
         public IMatcher<INilTerm> nil() {
@@ -342,11 +399,14 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> nil(Function1<? super INilTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, list -> {
-                return list.match(ListTerms.<Optional<R>>cases(cons -> Optional.empty(),
-                        nil -> Optional.of(f.apply(nil)), var -> Optional.empty()));
-            }, this::empty, this::empty, this::empty, this::empty));
-
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.INilTerm) {
+                    INilTerm nil = (INilTerm) subj;
+                    return Optional.of(f.apply(nil));
+                }
+                return Optional.empty();
+            };
         }
 
         // string
@@ -356,12 +416,18 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> string(Function1<? super IStringTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, this::empty,
-                    string -> Optional.of(f.apply(string)), this::empty, this::empty, this::empty));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IStringTerm) {
+                    IStringTerm string = (IStringTerm) subj;
+                    return Optional.of(f.apply(string));
+                }
+                return Optional.empty();
+            };
         }
 
         public IMatcher<String> stringValue() {
-            return string(s -> s.getValue());
+            return string(IStringTerm::getValue);
         }
 
         // integer
@@ -371,12 +437,18 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> integer(Function1<? super IIntTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, this::empty,
-                    this::empty, integer -> Optional.of(f.apply(integer)), this::empty, this::empty));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IIntTerm) {
+                    IIntTerm integer = (IIntTerm) subj;
+                    return Optional.of(f.apply(integer));
+                }
+                return Optional.empty();
+            };
         }
 
         public IMatcher<Integer> integerValue() {
-            return integer(i -> i.getValue());
+            return integer(IIntTerm::getValue);
         }
 
         // blob
@@ -386,8 +458,14 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> blob(Function1<? super IBlobTerm, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, this::empty,
-                    this::empty, this::empty, blob -> Optional.of(f.apply(blob)), this::empty));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.IBlobTerm) {
+                    IBlobTerm blob = (IBlobTerm) subj;
+                    return Optional.of(f.apply(blob));
+                }
+                return Optional.empty();
+            };
         }
 
         @SuppressWarnings("unchecked") public <T> IMatcher<T> blobValue(Class<T> blobClass) {
@@ -407,8 +485,14 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> var(Function1<? super ITermVar, R> f) {
-            return (term, unifier) -> unifier.findTerm(term).match(Terms.<Optional<R>>cases(this::empty, this::empty,
-                    this::empty, this::empty, this::empty, var -> Optional.of(f.apply(var))));
+            return (term, unifier) -> {
+                ITerm subj = unifier.findTerm(term);
+                if(subj.termTag() == ITerm.Tag.ITermVar) {
+                    ITermVar var = (ITermVar) subj;
+                    return Optional.of(f.apply(var));
+                }
+                return Optional.empty();
+            };
         }
 
         /**
@@ -461,10 +545,8 @@ public class TermMatch {
         }
 
         public <R> IMatcher<R> req(String msg, IMatcher<R> matcher) {
-            return (term, unifier) -> {
-                return matcher.match(term, unifier).map(Optional::of)
-                        .orElseThrow(() -> new IllegalArgumentException(msg + ": " + Unifiers.Immutable.of().toString(term, 4)));
-            };
+            return (term, unifier) -> matcher.match(term, unifier).map(Optional::of)
+                    .orElseThrow(() -> new IllegalArgumentException(msg + ": " + Unifiers.Immutable.of().toString(term, 4)));
         }
 
         @SuppressWarnings("unchecked") public <R extends ITerm> IMatcher<R> preserveAttachments(IMatcher<R> matcher) {
@@ -499,11 +581,6 @@ public class TermMatch {
             // @formatter:on
         }
 
-        // util
-
-        private <T> Optional<T> empty(@SuppressWarnings("unused") ITerm term) {
-            return Optional.empty();
-        }
     }
 
     @FunctionalInterface
@@ -549,7 +626,7 @@ public class TermMatch {
         }
 
         static <T> IMatcher<T> flatten(IMatcher<Optional<T>> m) {
-            return m.flatMap(o -> o)::match;
+            return m.flatMap(o -> o);
         }
 
     }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/substitution/FreshVars.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/substitution/FreshVars.java
@@ -3,6 +3,7 @@ package mb.nabl2.terms.substitution;
 import static mb.nabl2.terms.build.TermBuild.B;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.metaborg.util.collection.CapsuleUtil;
@@ -30,7 +31,7 @@ public class FreshVars {
     }
 
     @SafeVarargs public FreshVars(java.util.Set<ITermVar>... preExistingVarSets) {
-        this.oldVarSets = Lists.newArrayList(preExistingVarSets);
+        this.oldVarSets = new ArrayList<>(Arrays.asList(preExistingVarSets));
         this.oldVars = CapsuleUtil.immutableSet();
         this.newVars = CapsuleUtil.immutableSet();
     }

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/unification/RigidException.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/unification/RigidException.java
@@ -17,9 +17,9 @@ public class RigidException extends Exception {
         this.vars = ImmutableSet.of(var);
     }
 
-    public RigidException(ITermVar var1, ITermVar var2) {
+    public RigidException(ITermVar var, ITermVar var2) {
         super("rigid", null, false, false);
-        this.vars = ImmutableSet.of(var1, var2);
+        this.vars = ImmutableSet.of(var, var2);
     }
 
     public RigidException(Iterable<ITermVar> vars) {

--- a/nabl2.terms/src/main/java/mb/nabl2/terms/unification/ud/PersistentUniDisunifier.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/terms/unification/ud/PersistentUniDisunifier.java
@@ -114,9 +114,7 @@ public abstract class PersistentUniDisunifier extends BaseUniDisunifier implemen
             if((r = unifier.unify(left, right, isRigid).orElse(null)) == null) {
                 return Optional.empty();
             }
-            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> {
-                return new ImmutableResult<>(r.result(), ud);
-            });
+            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> new ImmutableResult<>(r.result(), ud));
         }
 
         @Override public Optional<IUniDisunifier.Result<IUnifier.Immutable>> unify(
@@ -126,9 +124,7 @@ public abstract class PersistentUniDisunifier extends BaseUniDisunifier implemen
             if((r = unifier.unify(equalities, isRigid).orElse(null)) == null) {
                 return Optional.empty();
             }
-            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> {
-                return new ImmutableResult<>(r.result(), ud);
-            });
+            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> new ImmutableResult<>(r.result(), ud));
         }
 
         @Override public Optional<IUniDisunifier.Result<IUnifier.Immutable>> unify(IUnifier other,
@@ -137,9 +133,7 @@ public abstract class PersistentUniDisunifier extends BaseUniDisunifier implemen
             if((r = unifier.unify(other, isRigid).orElse(null)) == null) {
                 return Optional.empty();
             }
-            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> {
-                return new ImmutableResult<>(r.result(), ud);
-            });
+            return normalizeDiseqs(r.unifier(), disequalities).map(ud -> new ImmutableResult<>(r.result(), ud));
         }
 
         @Override public Optional<IUniDisunifier.Result<IUnifier.Immutable>> uniDisunify(IUniDisunifier other,
@@ -156,9 +150,7 @@ public abstract class PersistentUniDisunifier extends BaseUniDisunifier implemen
                     unifier.addRangeVar(var, 1);
                 }
             }
-            return normalizeDiseqs(unifier.freeze(), disequalities.__insertAll(other.disequalities())).map(ud -> {
-                return new ImmutableResult<>(r.result(), ud);
-            });
+            return normalizeDiseqs(unifier.freeze(), disequalities.__insertAll(other.disequalities())).map(ud -> new ImmutableResult<>(r.result(), ud));
         }
 
         ///////////////////////////////////////////

--- a/nabl2.terms/src/main/java/mb/nabl2/util/collections/IndexedBagMultimap.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/util/collections/IndexedBagMultimap.java
@@ -1,5 +1,6 @@
 package mb.nabl2.util.collections;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -105,7 +106,7 @@ public class IndexedBagMultimap<K, V, I> {
     }
 
     public Collection<Entry> reindexAll(Function1<I, ? extends Iterable<? extends I>> normalize) {
-        return Lists.newArrayList(entries.keySet()).stream().flatMap(i -> reindex(i, normalize).stream())
+        return new ArrayList<>(entries.keySet()).stream().flatMap(i -> reindex(i, normalize).stream())
                 .collect(ImmutableList.toImmutableList());
     }
 

--- a/nabl2.terms/src/main/java/mb/nabl2/util/graph/alg/counting/CountingTcRelation.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/util/graph/alg/counting/CountingTcRelation.java
@@ -115,14 +115,10 @@ public class CountingTcRelation<V> implements ITcRelation<V> {
     public void deleteTupleEnd(V deleted) {
         Set<V> sourcesToDelete = CollectionsFactory.createSet();
         Set<V> targetsToDelete = CollectionsFactory.createSet();
-        
-        for (V target : tuplesForward.lookupOrEmpty(deleted).distinctValues()) {
-            targetsToDelete.add(target);
-        }
+
+        targetsToDelete.addAll(tuplesForward.lookupOrEmpty(deleted).distinctValues());
         if (tuplesBackward != null) {
-            for (V source : tuplesBackward.lookupOrEmpty(deleted).distinctValues()) {
-                sourcesToDelete.add(source);
-            }
+            sourcesToDelete.addAll(tuplesBackward.lookupOrEmpty(deleted).distinctValues());
         } else {
             for (V sourceCandidate : tuplesForward.distinctKeys()) {
                 if (tuplesForward.lookupOrEmpty(sourceCandidate).containsNonZero(deleted))

--- a/nabl2.terms/src/main/java/mb/nabl2/util/graph/alg/misc/CollectionsFactory.java
+++ b/nabl2.terms/src/main/java/mb/nabl2/util/graph/alg/misc/CollectionsFactory.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package mb.nabl2.util.graph.alg.misc;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public final class CollectionsFactory {
      * @since 1.7
      */
     public static <O> List<O> createObserverList() {
-        return Lists.newArrayList();
+        return new ArrayList<>();
     }
 
     /**

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -75,14 +75,6 @@ public class CArith implements IConstraint, Serializable {
         return new CArith(expr1, op, expr2, cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseArith(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseArith(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             expr1.getVars(),
@@ -129,6 +121,10 @@ public class CArith implements IConstraint, Serializable {
         sb.append(" #").append(op).append(" ");
         sb.append(expr2.toString(termToString));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CArith;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -51,14 +51,6 @@ public class CAstId implements IConstraint, Serializable {
         return new CAstId(term, idTerm, cause);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseTermId(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseTermId(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             term.getVars(),
@@ -101,6 +93,10 @@ public class CAstId implements IConstraint, Serializable {
         sb.append(termToString.format(idTerm));
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CAstId;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -76,14 +76,6 @@ public class CAstProperty implements IConstraint, Serializable {
         return new CAstProperty(idTerm, property, op, value, cause);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseTermProperty(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseTermProperty(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             idTerm.getVars(),
@@ -127,6 +119,10 @@ public class CAstProperty implements IConstraint, Serializable {
         sb.append(" ").append(op).append(" ");
         sb.append(termToString.format(value));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CAstProperty;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -42,13 +42,13 @@ public class CCompiledQuery extends AResolveQuery implements Serializable {
         return stateMachine;
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseCompiledQuery(this);
-    }
-
     @Override public <R, E extends Throwable> R matchInResolution(ResolutionFunction1<CResolveQuery, R> onResolveQuery,
             ResolutionFunction1<CCompiledQuery, R> onCompiledQuery) throws ResolutionException, InterruptedException {
         return onCompiledQuery.apply(this);
+    }
+
+    @Override public Tag resolveQueryTag() {
+        return Tag.CCompiledQuery;
     }
 
     @Override public CCompiledQuery withCause(IConstraint cause) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -51,14 +51,6 @@ public class CConj implements IConstraint, Serializable {
         return new CConj(left, right, cause);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseConj(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseConj(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             left.getVars(),
@@ -99,6 +91,10 @@ public class CConj implements IConstraint, Serializable {
         sb.append(", ");
         sb.append(right.toString(termToString));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CConj;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -70,14 +70,6 @@ public class CEqual implements IConstraint, Serializable {
         return new CEqual(term1, term2, cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseEqual(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseEqual(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             term1.getVars(),
@@ -121,6 +113,10 @@ public class CEqual implements IConstraint, Serializable {
         sb.append(" == ");
         sb.append(termToString.format(term2));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CEqual;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -81,15 +81,6 @@ public class CExists implements IConstraint, Serializable {
         return new CExists(vars, constraint, cause, criticalEdges, freeVars);
     }
 
-
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseExists(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseExists(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             vars,
@@ -190,6 +181,10 @@ public class CExists implements IConstraint, Serializable {
         sb.append("{").append(termToString.format(vars)).append("} ");
         sb.append(constraint.toString(termToString));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CExists;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -53,14 +53,6 @@ public class CFalse implements IConstraint, Serializable {
         return new CFalse(cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseFalse(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseFalse(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.of();
     }
@@ -95,6 +87,10 @@ public class CFalse implements IConstraint, Serializable {
 
     @Override public String toString(@SuppressWarnings("unused") TermFormatter termToString) {
         return "false";
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CFalse;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -75,14 +75,6 @@ public class CInequal implements IConstraint, Serializable {
         return new CInequal(universals, term1, term2, cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseInequal(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseInequal(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         final Set.Transient<ITermVar> vars = Set.Transient.of();
         vars.__insertAll(universals);
@@ -145,6 +137,10 @@ public class CInequal implements IConstraint, Serializable {
             sb.append(")");
         }
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CInequal;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -47,14 +47,6 @@ public class CNew implements IConstraint, Serializable {
         return datumTerm;
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseNew(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseNew(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             scopeTerm.getVars(),
@@ -115,6 +107,10 @@ public class CNew implements IConstraint, Serializable {
         sb.append(" : ");
         sb.append(termToString.format(datumTerm));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CNew;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -33,13 +33,13 @@ public class CResolveQuery extends AResolveQuery implements Serializable {
         super(filter, min, scopeTerm, resultTerm, cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseResolveQuery(this);
-    }
-
     @Override public <R, E extends Throwable> R matchInResolution(ResolutionFunction1<CResolveQuery, R> onResolveQuery,
             ResolutionFunction1<CCompiledQuery, R> onCompiledQuery) throws ResolutionException, InterruptedException {
         return onResolveQuery.apply(this);
+    }
+
+    @Override public Tag resolveQueryTag() {
+        return Tag.CResolveQuery;
     }
 
     @Override public CResolveQuery withCause(@Nullable IConstraint cause) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -69,14 +69,6 @@ public class CTellEdge implements IConstraint, Serializable {
         return new CTellEdge(sourceTerm, label, targetTerm, cause, criticalEdges);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseTellEdge(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseTellEdge(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.union(
             sourceTerm.getVars(),
@@ -122,6 +114,10 @@ public class CTellEdge implements IConstraint, Serializable {
         sb.append("-> ");
         sb.append(termToString.format(targetTerm));
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CTellEdge;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -38,14 +38,6 @@ public class CTrue implements IConstraint, Serializable {
         return new CTrue(cause);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseTrue(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseTrue(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return Set.Immutable.of();
     }
@@ -77,6 +69,10 @@ public class CTrue implements IConstraint, Serializable {
 
     @Override public String toString(@SuppressWarnings("unused") TermFormatter termToString) {
         return "true";
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CTrue;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -60,14 +60,6 @@ public class CTry implements IConstraint, Serializable {
         return new CTry(constraint, cause, message);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseTry(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseTry(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         return constraint.getVars();
     }
@@ -107,6 +99,10 @@ public class CTry implements IConstraint, Serializable {
         sb.append(constraint.toString(termToString));
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CTry;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -81,14 +81,6 @@ public class CUser implements IConstraint, Serializable {
         return new CUser(name, args, cause, message, criticalEdges);
     }
 
-    @Override public <R> R match(Cases<R> cases) {
-        return cases.caseUser(this);
-    }
-
-    @Override public <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E {
-        return cases.caseUser(this);
-    }
-
     @Override public Set.Immutable<ITermVar> getVars() {
         final Set.Transient<ITermVar> vars = Set.Transient.of();
         for(ITerm a : args) {
@@ -136,6 +128,10 @@ public class CUser implements IConstraint, Serializable {
         sb.append(termToString.format(args));
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override public Tag constraintTag() {
+        return Tag.CUser;
     }
 
     @Override public String toString() {

--- a/statix.solver/src/main/java/mb/statix/constraints/Constraints.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/Constraints.java
@@ -30,344 +30,45 @@ public final class Constraints {
     private Constraints() {
     }
 
-    // @formatter:off
-    public static <R> IConstraint.Cases<R> cases(
-                Function1<CArith, R> onArith,
-                Function1<CConj,R> onConj,
-                Function1<CEqual,R> onEqual,
-                Function1<CExists,R> onExists,
-                Function1<CFalse,R> onFalse,
-                Function1<CInequal,R> onInequal,
-                Function1<CNew,R> onNew,
-                Function1<IResolveQuery,R> onResolveQuery,
-                Function1<CTellEdge,R> onTellEdge,
-                Function1<CAstId,R> onTermId,
-                Function1<CAstProperty,R> onTermProperty,
-                Function1<CTrue,R> onTrue,
-                Function1<CTry,R> onTry,
-                Function1<CUser,R> onUser
-            ) {
-        return new IConstraint.Cases<R>() {
-
-            @Override public R caseArith(CArith c) {
-                return onArith.apply(c);
-            }
-
-            @Override public R caseConj(CConj c) {
-                return onConj.apply(c);
-            }
-
-            @Override public R caseEqual(CEqual c) {
-                return onEqual.apply(c);
-            }
-
-            @Override public R caseExists(CExists c) {
-                return onExists.apply(c);
-            }
-
-            @Override public R caseFalse(CFalse c) {
-                return onFalse.apply(c);
-            }
-
-            @Override public R caseInequal(CInequal c) {
-                return onInequal.apply(c);
-            }
-
-            @Override public R caseNew(CNew c) {
-                return onNew.apply(c);
-            }
-
-            @Override public R caseResolveQuery(IResolveQuery c) {
-                return onResolveQuery.apply(c);
-            }
-
-            @Override public R caseTellEdge(CTellEdge c) {
-                return onTellEdge.apply(c);
-            }
-
-            @Override public R caseTermId(CAstId c) {
-                return onTermId.apply(c);
-            }
-
-            @Override public R caseTermProperty(CAstProperty c) {
-                return onTermProperty.apply(c);
-            }
-
-            @Override public R caseTrue(CTrue c) {
-                return onTrue.apply(c);
-            }
-
-            @Override public R caseTry(CTry c) {
-                return onTry.apply(c);
-            }
-
-            @Override public R caseUser(CUser c) {
-                return onUser.apply(c);
-            }
-
-        };
-    }
-    // @formatter:on
-
-    public static <R> CaseBuilder<R> cases() {
-        return new CaseBuilder<>();
-    }
-
-    public static class CaseBuilder<R> {
-
-        private Function1<CArith, R> onArith;
-        private Function1<CConj, R> onConj;
-        private Function1<CEqual, R> onEqual;
-        private Function1<CExists, R> onExists;
-        private Function1<CFalse, R> onFalse;
-        private Function1<CInequal, R> onInequal;
-        private Function1<CNew, R> onNew;
-        private Function1<IResolveQuery, R> onResolveQuery;
-        private Function1<CTellEdge, R> onTellEdge;
-        private Function1<CAstId, R> onTermId;
-        private Function1<CAstProperty, R> onTermProperty;
-        private Function1<CTrue, R> onTrue;
-        private Function1<CTry, R> onTry;
-        private Function1<CUser, R> onUser;
-
-        public CaseBuilder<R> arith(Function1<CArith, R> onArith) {
-            this.onArith = onArith;
-            return this;
-        }
-
-        public CaseBuilder<R> conj(Function1<CConj, R> onConj) {
-            this.onConj = onConj;
-            return this;
-        }
-
-        public CaseBuilder<R> equal(Function1<CEqual, R> onEqual) {
-            this.onEqual = onEqual;
-            return this;
-        }
-
-        public CaseBuilder<R> exists(Function1<CExists, R> onExists) {
-            this.onExists = onExists;
-            return this;
-        }
-
-        public CaseBuilder<R> _false(Function1<CFalse, R> onFalse) {
-            this.onFalse = onFalse;
-            return this;
-        }
-
-        public CaseBuilder<R> inequal(Function1<CInequal, R> onInequal) {
-            this.onInequal = onInequal;
-            return this;
-        }
-
-        public CaseBuilder<R> _new(Function1<CNew, R> onNew) {
-            this.onNew = onNew;
-            return this;
-        }
-
-        public CaseBuilder<R> resolveQuery(Function1<IResolveQuery, R> onResolveQuery) {
-            this.onResolveQuery = onResolveQuery;
-            return this;
-        }
-
-        public CaseBuilder<R> tellEdge(Function1<CTellEdge, R> onTellEdge) {
-            this.onTellEdge = onTellEdge;
-            return this;
-        }
-
-        public CaseBuilder<R> termId(Function1<CAstId, R> onTermId) {
-            this.onTermId = onTermId;
-            return this;
-        }
-
-        public CaseBuilder<R> termProperty(Function1<CAstProperty, R> onTermProperty) {
-            this.onTermProperty = onTermProperty;
-            return this;
-        }
-
-        public CaseBuilder<R> _true(Function1<CTrue, R> onTrue) {
-            this.onTrue = onTrue;
-            return this;
-        }
-
-        public CaseBuilder<R> _try(Function1<CTry, R> onTry) {
-            this.onTry = onTry;
-            return this;
-        }
-
-        public CaseBuilder<R> user(Function1<CUser, R> onUser) {
-            this.onUser = onUser;
-            return this;
-        }
-
-        public IConstraint.Cases<R> otherwise(Function1<IConstraint, R> otherwise) {
-            return new IConstraint.Cases<R>() {
-
-                @Override public R caseArith(CArith c) {
-                    return onArith != null ? onArith.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseConj(CConj c) {
-                    return onConj != null ? onConj.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseEqual(CEqual c) {
-                    return onEqual != null ? onEqual.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseExists(CExists c) {
-                    return onExists != null ? onExists.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseFalse(CFalse c) {
-                    return onFalse != null ? onFalse.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseInequal(CInequal c) {
-                    return onInequal != null ? onInequal.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseNew(CNew c) {
-                    return onNew != null ? onNew.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseResolveQuery(IResolveQuery c) {
-                    return onResolveQuery != null ? onResolveQuery.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseTellEdge(CTellEdge c) {
-                    return onTellEdge != null ? onTellEdge.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseTermId(CAstId c) {
-                    return onTermId != null ? onTermId.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseTermProperty(CAstProperty c) {
-                    return onTermProperty != null ? onTermProperty.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseTrue(CTrue c) {
-                    return onTrue != null ? onTrue.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseTry(CTry c) {
-                    return onTry != null ? onTry.apply(c) : otherwise.apply(c);
-                }
-
-                @Override public R caseUser(CUser c) {
-                    return onUser != null ? onUser.apply(c) : otherwise.apply(c);
-                }
-
-            };
-        }
-
-    }
-
-
-    // @formatter:off
-    public static <R, E extends Throwable> IConstraint.CheckedCases<R, E> checkedCases(
-                CheckedFunction1<CArith, R, E> onArith,
-                CheckedFunction1<CConj, R, E> onConj,
-                CheckedFunction1<CEqual, R, E> onEqual,
-                CheckedFunction1<CExists, R, E> onExists,
-                CheckedFunction1<CFalse, R, E> onFalse,
-                CheckedFunction1<CInequal, R, E> onInequal,
-                CheckedFunction1<CNew, R, E> onNew,
-                CheckedFunction1<IResolveQuery, R, E> onResolveQuery,
-                CheckedFunction1<CTellEdge, R, E> onTellEdge,
-                CheckedFunction1<CAstId, R, E> onTermId,
-                CheckedFunction1<CAstProperty, R, E> onTermProperty,
-                CheckedFunction1<CTrue, R, E> onTrue,
-                CheckedFunction1<CTry, R, E> onTry,
-                CheckedFunction1<CUser, R, E> onUser
-            ) {
-        return new IConstraint.CheckedCases<R, E>() {
-
-            @Override public R caseArith(CArith c) throws E {
-                return onArith.apply(c);
-            }
-
-            @Override public R caseConj(CConj c) throws E {
-                return onConj.apply(c);
-            }
-
-            @Override public R caseEqual(CEqual c) throws E {
-                return onEqual.apply(c);
-            }
-
-            @Override public R caseExists(CExists c) throws E {
-                return onExists.apply(c);
-            }
-
-            @Override public R caseFalse(CFalse c) throws E {
-                return onFalse.apply(c);
-            }
-
-            @Override public R caseInequal(CInequal c) throws E {
-                return onInequal.apply(c);
-            }
-
-            @Override public R caseNew(CNew c) throws E {
-                return onNew.apply(c);
-            }
-
-            @Override public R caseResolveQuery(IResolveQuery c) throws E {
-                return onResolveQuery.apply(c);
-            }
-
-            @Override public R caseTellEdge(CTellEdge c) throws E {
-                return onTellEdge.apply(c);
-            }
-
-            @Override public R caseTermId(CAstId c) throws E {
-                return onTermId.apply(c);
-            }
-
-            @Override public R caseTermProperty(CAstProperty c) throws E {
-                return onTermProperty.apply(c);
-            }
-
-            @Override public R caseTrue(CTrue c) throws E {
-                return onTrue.apply(c);
-            }
-
-            @Override public R caseTry(CTry c) throws E {
-                return onTry.apply(c);
-            }
-
-            @Override public R caseUser(CUser c) throws E {
-                return onUser.apply(c);
-            }
-
-        };
-    }
-    // @formatter:on
-
     /**
      * Bottom up transformation, where the transformation is applied starting from the leaves, then to the transformed
      * parents until the root.
      */
     public static Function1<IConstraint, IConstraint> bottomup(Function1<IConstraint, IConstraint> f,
             boolean recurseInLogicalScopes) {
-        // @formatter:off
-        return cases(
-            c -> f.apply(c),
-            c -> f.apply(new CConj(bottomup(f, recurseInLogicalScopes).apply(c.left()), bottomup(f, recurseInLogicalScopes).apply(c.right()), c.cause().orElse(null))),
-            c -> f.apply(c),
-            c -> f.apply(new CExists(c.vars(), bottomup(f, recurseInLogicalScopes).apply(c.constraint()), c.cause().orElse(null))),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(recurseInLogicalScopes ? new CTry(bottomup(f, recurseInLogicalScopes).apply(c.constraint()), c.cause().orElse(null), c.message().orElse(null)) : c),
-            c -> f.apply(c)
-        );
-        // @formatter:on
+        return constraint -> {
+            switch(constraint.constraintTag()) {
+                case CConj: {
+                    CConj c = (CConj) constraint;
+                    return f.apply(new CConj(bottomup(f, recurseInLogicalScopes).apply(c.left()),
+                        bottomup(f, recurseInLogicalScopes).apply(c.right()), c.cause().orElse(null)));
+                }
+                case CExists: {
+                    CExists c = (CExists) constraint;
+                    return f.apply(new CExists(c.vars(), bottomup(f, recurseInLogicalScopes).apply(c.constraint()),
+                        c.cause().orElse(null)));
+                }
+                case CTry: {
+                    CTry c = (CTry) constraint;
+                    return f.apply(recurseInLogicalScopes ? new CTry(bottomup(f, recurseInLogicalScopes).apply(c.constraint()),
+                        c.cause().orElse(null), c.message().orElse(null)) : c);
+                }
+                case CArith:
+                case CEqual:
+                case CFalse:
+                case CInequal:
+                case CNew:
+                case IResolveQuery:
+                case CTellEdge:
+                case CAstId:
+                case CAstProperty:
+                case CTrue:
+                case CUser:
+                    return f.apply(constraint);
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IConstraint subclass/tag");
+        };
     }
 
     /**
@@ -375,38 +76,44 @@ public final class Constraints {
      */
     public static Function1<IConstraint, IConstraint> map(Function1<IConstraint, IConstraint> f,
             boolean recurseInLogicalScopes) {
-        // @formatter:off
-        return cases(
-            c -> f.apply(c),
-            c -> {
-                final IConstraint left = map(f, recurseInLogicalScopes).apply(c.left());
-                final IConstraint right = map(f, recurseInLogicalScopes).apply(c.right());
-                return new CConj(left, right, c.cause().orElse(null));
-            },
-            c -> f.apply(c),
-            c -> {
-                final IConstraint body = map(f, recurseInLogicalScopes).apply(c.constraint());
-                return new CExists(c.vars(), body, c.cause().orElse(null));
-            },
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> {
-                if(recurseInLogicalScopes) {
-                    final IConstraint body = map(f, recurseInLogicalScopes).apply(c.constraint());
-                    return new CTry(body, c.cause().orElse(null), c.message().orElse(null));
-                } else {
-                    return c;
+        return constraint -> {
+            switch(constraint.constraintTag()) {
+                case CConj: {
+                    CConj c = (CConj) constraint;
+                    final IConstraint left = map(f, recurseInLogicalScopes).apply(c.left());
+                    final IConstraint right = map(f, recurseInLogicalScopes).apply(c.right());
+                    return new CConj(left, right, c.cause().orElse(null));
                 }
-            },
-            c -> f.apply(c)
-        );
-        // @formatter:on
+                case CExists: {
+                    CExists c = (CExists) constraint;
+                    final IConstraint body = map(f, recurseInLogicalScopes).apply(c.constraint());
+                    return new CExists(c.vars(), body, c.cause().orElse(null));
+                }
+                case CTry: {
+                    CTry c = (CTry) constraint;
+                    if(recurseInLogicalScopes) {
+                        final IConstraint body = map(f, recurseInLogicalScopes).apply(c.constraint());
+                        return new CTry(body, c.cause().orElse(null), c.message().orElse(null));
+                    } else {
+                        return c;
+                    }
+                }
+                case CArith:
+                case CEqual:
+                case CFalse:
+                case CInequal:
+                case CNew:
+                case IResolveQuery:
+                case CTellEdge:
+                case CAstId:
+                case CAstProperty:
+                case CTrue:
+                case CUser:
+                    return f.apply(constraint);
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IConstraint subclass/tag");
+        };
     }
 
     /**
@@ -414,38 +121,44 @@ public final class Constraints {
      */
     public static Function1<IConstraint, Optional<IConstraint>> filter(Function1<IConstraint, Optional<IConstraint>> f,
             boolean recurseInLogicalScopes) {
-        // @formatter:off
-        return cases(
-            c -> f.apply(c),
-            c -> {
-                final Optional<IConstraint> left = filter(f, recurseInLogicalScopes).apply(c.left());
-                final Optional<IConstraint> right = filter(f, recurseInLogicalScopes).apply(c.right());
-                return Optionals.lift(left, right, (l, r) -> new CConj(l, r, c.cause().orElse(null)));
-            },
-            c -> f.apply(c),
-            c -> {
-                final Optional<IConstraint> body = filter(f, recurseInLogicalScopes).apply(c.constraint());
-                return body.map(b -> new CExists(c.vars(), b, c.cause().orElse(null)));
-            },
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> {
-                if(recurseInLogicalScopes) {
-                    final Optional<IConstraint> body = filter(f, recurseInLogicalScopes).apply(c.constraint());
-                    return body.map(b -> new CTry(b, c.cause().orElse(null), c.message().orElse(null)));
-                } else {
-                    return Optional.of(c);
+        return constraint -> {
+            switch(constraint.constraintTag()) {
+                case CConj: {
+                    CConj c = (CConj) constraint;
+                    final Optional<IConstraint> left = filter(f, recurseInLogicalScopes).apply(c.left());
+                    final Optional<IConstraint> right = filter(f, recurseInLogicalScopes).apply(c.right());
+                    return Optionals.lift(left, right, (l, r) -> new CConj(l, r, c.cause().orElse(null)));
                 }
-            },
-            c -> f.apply(c)
-        );
-        // @formatter:on
+                case CExists: {
+                    CExists c = (CExists) constraint;
+                    final Optional<IConstraint> body = filter(f, recurseInLogicalScopes).apply(c.constraint());
+                    return body.map(b -> new CExists(c.vars(), b, c.cause().orElse(null)));
+                }
+                case CTry: {
+                    CTry c = (CTry) constraint;
+                    if(recurseInLogicalScopes) {
+                        final Optional<IConstraint> body = filter(f, recurseInLogicalScopes).apply(c.constraint());
+                        return body.map(b -> new CTry(b, c.cause().orElse(null), c.message().orElse(null)));
+                    } else {
+                        return Optional.of(c);
+                    }
+                }
+                case CArith:
+                case CEqual:
+                case CFalse:
+                case CInequal:
+                case CNew:
+                case IResolveQuery:
+                case CTellEdge:
+                case CAstId:
+                case CAstProperty:
+                case CTrue:
+                case CUser:
+                    return f.apply(constraint);
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IConstraint subclass/tag");
+        };
     }
 
     /**
@@ -453,42 +166,48 @@ public final class Constraints {
      */
     public static Function1<IConstraint, Stream<IConstraint>> flatMap(Function1<IConstraint, Stream<IConstraint>> f,
             boolean recurseInLogicalScopes) {
-        // @formatter:off
-        return cases(
-            c -> f.apply(c),
-            c -> {
-                return flatMap(f, recurseInLogicalScopes).apply(c.left()).flatMap(l -> {
-                    return flatMap(f, recurseInLogicalScopes).apply(c.right()).map(r -> {
-                        return new CConj(l, r, c.cause().orElse(null));
+        return constraint -> {
+            switch(constraint.constraintTag()) {
+                case CConj: {
+                    CConj c = (CConj) constraint;
+                    return flatMap(f, recurseInLogicalScopes).apply(c.left()).flatMap(l -> {
+                        return flatMap(f, recurseInLogicalScopes).apply(c.right()).map(r -> {
+                            return new CConj(l, r, c.cause().orElse(null));
+                        });
                     });
-                });
-            },
-            c -> f.apply(c),
-            c -> {
-                return flatMap(f, recurseInLogicalScopes).apply(c.constraint()).map(b -> {
-                    return new CExists(c.vars(), b, c.cause().orElse(null));
-                });
-            },
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> f.apply(c),
-            c -> {
-                if(recurseInLogicalScopes) {
-                    return flatMap(f, recurseInLogicalScopes).apply(c.constraint()).map(b -> {
-                        return new CTry(b, c.cause().orElse(null), c.message().orElse(null));
-                    });
-                } else {
-                    return Stream.of(c);
                 }
-            },
-            c -> f.apply(c)
-        );
-        // @formatter:on
+                case CExists: {
+                    CExists c = (CExists) constraint;
+                    return flatMap(f, recurseInLogicalScopes).apply(c.constraint()).map(b -> {
+                        return new CExists(c.vars(), b, c.cause().orElse(null));
+                    });
+                }
+                case CTry: {
+                    CTry c = (CTry) constraint;
+                    if(recurseInLogicalScopes) {
+                        return flatMap(f, recurseInLogicalScopes).apply(c.constraint()).map(b -> {
+                            return new CTry(b, c.cause().orElse(null), c.message().orElse(null));
+                        });
+                    } else {
+                        return Stream.of(c);
+                    }
+                }
+                case CArith:
+                case CEqual:
+                case CFalse:
+                case CInequal:
+                case CNew:
+                case IResolveQuery:
+                case CTellEdge:
+                case CAstId:
+                case CAstProperty:
+                case CTrue:
+                case CUser:
+                    return f.apply(constraint);
+            }
+            // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+            throw new RuntimeException("Missing case for IConstraint subclass/tag");
+        };
     }
 
     public static <T> Function1<IConstraint, List<T>> collectBase(PartialFunction1<IConstraint, T> f,
@@ -501,25 +220,42 @@ public final class Constraints {
     }
 
     private static <T> void collectBase(IConstraint constraint, PartialFunction1<IConstraint, T> f,
-            ImmutableList.Builder<T> ts, boolean recurseInLogicalScopes) {
-        // @formatter:off
-        constraint.match(cases(
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { disjoin(c).forEach(cc -> collectBase(cc, f, ts, recurseInLogicalScopes)); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { disjoin(c.constraint()).forEach(cc -> collectBase(cc, f, ts, recurseInLogicalScopes)); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; },
-            c -> { if(recurseInLogicalScopes) { disjoin(c.constraint()).forEach(cc -> collectBase(cc, f, ts, recurseInLogicalScopes)); } return Unit.unit; },
-            c -> { f.apply(c).ifPresent(ts::add); return Unit.unit; }
-        ));
-        // @formatter:on
+        ImmutableList.Builder<T> ts, boolean recurseInLogicalScopes) {
+        switch(constraint.constraintTag()) {
+            case CConj: {
+                CConj c = (CConj) constraint;
+                disjoin(c).forEach(cc -> collectBase(cc, f, ts, recurseInLogicalScopes));
+                break;
+            }
+            case CExists: {
+                CExists c = (CExists) constraint;
+                disjoin(c.constraint()).forEach(
+                    cc -> collectBase(cc, f, ts, recurseInLogicalScopes));
+                break;
+            }
+            case CTry: {
+                CTry c = (CTry) constraint;
+                if(recurseInLogicalScopes) {
+                    disjoin(c.constraint()).forEach(
+                        cc -> collectBase(cc, f, ts, recurseInLogicalScopes));
+                }
+                break;
+            }
+            case CArith:
+            case CEqual:
+            case CFalse:
+            case CInequal:
+            case CNew:
+            case IResolveQuery:
+            case CTellEdge:
+            case CAstId:
+            case CAstProperty:
+            case CTrue:
+            case CUser: {
+                f.apply(constraint).ifPresent(ts::add);
+                break;
+            }
+        }
     }
 
     public static List<IConstraint> apply(List<IConstraint> constraints, ISubstitution.Immutable subst) {
@@ -583,18 +319,20 @@ public final class Constraints {
         Deque<IConstraint> worklist = Lists.newLinkedList();
         worklist.push(constraint);
         while(!worklist.isEmpty()) {
-            worklist.pop().match(Constraints.cases().conj(conj -> {
+            IConstraint c = worklist.pop();
+            if(c.constraintTag() == IConstraint.Tag.CConj) {
+                CConj conj = (CConj) c;
                 // HEURISTIC Use the cause of the surrounding conjunction, or keep
                 //           the cause of the constraints. This is a heuristic which seems
                 //           to work well, but in general maintaining causes requires some
                 //           care throughout the solver code.
-                worklist.push(conj.left().withCause(conj.cause().orElse(conj.left().cause().orElse(null))));
-                worklist.push(conj.right().withCause(conj.cause().orElse(conj.right().cause().orElse(null))));
-                return Unit.unit;
-            }).otherwise(c -> {
+                worklist.push(
+                    conj.left().withCause(conj.cause().orElse(conj.left().cause().orElse(null))));
+                worklist.push(
+                    conj.right().withCause(conj.cause().orElse(conj.right().cause().orElse(null))));
+            } else {
                 action.apply(c);
-                return Unit.unit;
-            }));
+            }
         }
     }
 
@@ -615,74 +353,84 @@ public final class Constraints {
     }
 
     public static void vars(IConstraint constraint, Action1<ITermVar> onVar) {
-        // @formatter:off
-        constraint.match(Constraints.cases(
-            onArith -> {
+        switch(constraint.constraintTag()) {
+            case CArith: {
+                CArith onArith = (CArith) constraint;
                 onArith.expr1().isTerm().ifPresent(t -> t.getVars().forEach(onVar::apply));
                 onArith.expr2().isTerm().ifPresent(t -> t.getVars().forEach(onVar::apply));
-                return Unit.unit;
-            },
-            onConj -> {
+                break;
+            }
+            case CConj: {
+                CConj onConj = (CConj) constraint;
                 Constraints.disjoin(onConj).forEach(c -> vars(c, onVar));
-                return Unit.unit;
-            },
-            onEqual -> {
+                break;
+            }
+            case CEqual: {
+                CEqual onEqual = (CEqual) constraint;
                 onEqual.term1().getVars().forEach(onVar::apply);
                 onEqual.term2().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onExists -> {
+                break;
+            }
+            case CExists: {
+                CExists onExists = (CExists) constraint;
                 onExists.vars().forEach(onVar::apply);
                 vars(onExists.constraint(), onVar);
-                return Unit.unit;
-            },
-            onFalse -> {
-                return Unit.unit;
-            },
-            onInequal -> {
-                onInequal.term1().getVars().stream().filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
-                onInequal.term2().getVars().stream().filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onNew -> {
+                break;
+            }
+            case CFalse:
+            case CTrue:
+                break;
+            case CInequal: {
+                CInequal onInequal = (CInequal) constraint;
+                onInequal.term1().getVars().stream()
+                    .filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
+                onInequal.term2().getVars().stream()
+                    .filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
+                break;
+            }
+            case CNew: {
+                CNew onNew = (CNew) constraint;
                 onNew.scopeTerm().getVars().forEach(onVar::apply);
                 onNew.datumTerm().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onResolveQuery -> {
+                break;
+            }
+            case IResolveQuery: {
+                IResolveQuery onResolveQuery = (IResolveQuery) constraint;
                 onResolveQuery.scopeTerm().getVars().forEach(onVar::apply);
                 RuleUtil.vars(onResolveQuery.filter().getDataWF(), onVar);
                 RuleUtil.vars(onResolveQuery.min().getDataEquiv(), onVar);
                 onResolveQuery.resultTerm().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onTellEdge -> {
+                break;
+            }
+            case CTellEdge: {
+                CTellEdge onTellEdge = (CTellEdge) constraint;
                 onTellEdge.sourceTerm().getVars().forEach(onVar::apply);
                 onTellEdge.targetTerm().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onTermId -> {
+                break;
+            }
+            case CAstId: {
+                CAstId onTermId = (CAstId) constraint;
                 onTermId.astTerm().getVars().forEach(onVar::apply);
                 onTermId.idTerm().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onTermProperty -> {
+                break;
+            }
+            case CAstProperty: {
+                CAstProperty onTermProperty = (CAstProperty) constraint;
                 onTermProperty.idTerm().getVars().forEach(onVar::apply);
                 onTermProperty.value().getVars().forEach(onVar::apply);
-                return Unit.unit;
-            },
-            onTrue -> null,
-            onTry -> {
-                vars(onTry.constraint(), onVar);
-                return Unit.unit;
-            },
-            onUser -> {
-                onUser.args().forEach(t -> t.getVars().forEach(onVar::apply));
-                return Unit.unit;
+                break;
             }
-        ));
-        // @formatter:on
-
+            case CTry: {
+                CTry onTry = (CTry) constraint;
+                vars(onTry.constraint(), onVar);
+                break;
+            }
+            case CUser: {
+                CUser onUser = (CUser) constraint;
+                onUser.args().forEach(t -> t.getVars().forEach(onVar::apply));
+                break;
+            }
+        }
     }
 
     public static IConstraint exists(Iterable<ITermVar> vars, IConstraint body) {
@@ -704,9 +452,14 @@ public final class Constraints {
      * otherwise, none
      */
     public static Optional<Boolean> trivial(IConstraint constraint) {
-        return Optional.ofNullable(
-                constraint.match(Constraints.cases(c -> null, c -> null, c -> null, c -> null, c -> false, c -> null,
-                        c -> null, c -> null, c -> null, c -> null, c -> null, c -> true, c -> null, c -> null)));
+        switch(constraint.constraintTag()) {
+            case CTrue:
+                return Optional.of(true);
+            case CFalse:
+                return Optional.of(false);
+            default:
+                return Optional.empty();
+        }
     }
 
 }

--- a/statix.solver/src/main/java/mb/statix/constraints/Constraints.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/Constraints.java
@@ -326,10 +326,8 @@ public final class Constraints {
                 //           the cause of the constraints. This is a heuristic which seems
                 //           to work well, but in general maintaining causes requires some
                 //           care throughout the solver code.
-                worklist.push(
-                    conj.left().withCause(conj.cause().orElse(conj.left().cause().orElse(null))));
-                worklist.push(
-                    conj.right().withCause(conj.cause().orElse(conj.right().cause().orElse(null))));
+                worklist.push(conj.left().withCause(conj.cause().orElse(conj.left().cause().orElse(null))));
+                worklist.push(conj.right().withCause(conj.cause().orElse(conj.right().cause().orElse(null))));
             } else {
                 action.apply(c);
             }
@@ -377,15 +375,10 @@ public final class Constraints {
                 vars(onExists.constraint(), onVar);
                 break;
             }
-            case CFalse:
-            case CTrue:
-                break;
             case CInequal: {
                 CInequal onInequal = (CInequal) constraint;
-                onInequal.term1().getVars().stream()
-                    .filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
-                onInequal.term2().getVars().stream()
-                    .filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
+                onInequal.term1().getVars().stream().filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
+                onInequal.term2().getVars().stream().filter(v -> !onInequal.universals().contains(v)).forEach(onVar::apply);
                 break;
             }
             case CNew: {
@@ -430,6 +423,9 @@ public final class Constraints {
                 onUser.args().forEach(t -> t.getVars().forEach(onVar::apply));
                 break;
             }
+            case CFalse:
+            case CTrue:
+                break;
         }
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
@@ -18,33 +18,21 @@ public interface IResolveQuery extends IConstraint {
 
     ITerm resultTerm();
 
-    <R> R match(Cases<R> cases);
-
     <R, E extends Throwable> R matchInResolution(ResolutionFunction1<CResolveQuery, R> onResolveQuery,
             ResolutionFunction1<CCompiledQuery, R> onCompiledQuery) throws ResolutionException, InterruptedException;
-
-    @Override default <R> R match(IConstraint.Cases<R> cases) {
-        return cases.caseResolveQuery(this);
-    }
-
-    @Override default <R, E extends Throwable> R matchOrThrow(IConstraint.CheckedCases<R, E> cases) throws E {
-        return cases.caseResolveQuery(this);
-    }
-
-    interface Cases<R> extends Function1<IResolveQuery, R> {
-
-        R caseResolveQuery(CResolveQuery q);
-
-        R caseCompiledQuery(CCompiledQuery q);
-
-        @Override default R apply(IResolveQuery q) {
-            return q.match(this);
-        }
-
-    }
 
     interface ResolutionFunction1<T, R> {
         R apply(T t) throws ResolutionException, InterruptedException;
     }
 
+    @Override default IConstraint.Tag constraintTag() {
+        return IConstraint.Tag.IResolveQuery;
+    }
+
+    enum Tag {
+        CResolveQuery,
+        CCompiledQuery
+    }
+
+    Tag resolveQueryTag();
 }

--- a/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
@@ -65,10 +65,6 @@ public interface IConstraint {
         throw new UnsupportedOperationException("Constraint does not support body critical edges.");
     }
 
-    <R> R match(Cases<R> cases);
-
-    <R, E extends Throwable> R matchOrThrow(CheckedCases<R, E> cases) throws E;
-
     Set.Immutable<ITermVar> getVars();
 
     Set.Immutable<ITermVar> freeVars();
@@ -92,76 +88,23 @@ public interface IConstraint {
 
     String toString(TermFormatter termToString);
 
-    interface Cases<R> extends Function1<IConstraint, R> {
+    Tag constraintTag();
 
-        R caseArith(CArith c);
-
-        R caseConj(CConj c);
-
-        R caseEqual(CEqual c);
-
-        R caseExists(CExists c);
-
-        R caseFalse(CFalse c);
-
-        R caseInequal(CInequal c);
-
-        R caseNew(CNew c);
-
-        R caseResolveQuery(IResolveQuery c);
-
-        R caseTellEdge(CTellEdge c);
-
-        R caseTermId(CAstId c);
-
-        R caseTermProperty(CAstProperty c);
-
-        R caseTrue(CTrue c);
-
-        R caseTry(CTry c);
-
-        R caseUser(CUser c);
-
-        @Override default R apply(IConstraint c) {
-            return c.match(this);
-        }
-
-    }
-
-    interface CheckedCases<R, E extends Throwable> extends CheckedFunction1<IConstraint, R, E> {
-
-        R caseArith(CArith c) throws E;
-
-        R caseConj(CConj c) throws E;
-
-        R caseEqual(CEqual c) throws E;
-
-        R caseExists(CExists c) throws E;
-
-        R caseFalse(CFalse c) throws E;
-
-        R caseInequal(CInequal c) throws E;
-
-        R caseNew(CNew c) throws E;
-
-        R caseResolveQuery(IResolveQuery c) throws E;
-
-        R caseTellEdge(CTellEdge c) throws E;
-
-        R caseTermId(CAstId c) throws E;
-
-        R caseTermProperty(CAstProperty c) throws E;
-
-        R caseTrue(CTrue c) throws E;
-
-        R caseTry(CTry c) throws E;
-
-        R caseUser(CUser c) throws E;
-
-        @Override default R apply(IConstraint c) throws E {
-            return c.matchOrThrow(this);
-        }
-
+    enum Tag {
+        CArith,
+        CConj,
+        CEqual,
+        CExists,
+        CFalse,
+        CInequal,
+        CNew,
+        IResolveQuery,
+        CTellEdge,
+        CAstId,
+        CAstProperty,
+        CTrue,
+        CTry,
+        CUser
     }
 
 }

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -321,9 +321,8 @@ class GreedySolver {
         }
 
         // solve
-        return constraint.matchOrThrow(new IConstraint.CheckedCases<Boolean, InterruptedException>() {
-
-            @Override public Boolean caseArith(CArith c) throws InterruptedException {
+        switch(constraint.constraintTag()) {
+            case CArith: { CArith c = (CArith) constraint;
                 final IUniDisunifier unifier = state.unifier();
                 final Optional<ITerm> term1 = c.expr1().isTerm();
                 final Optional<ITerm> term2 = c.expr2().isTerm();
@@ -353,11 +352,11 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseConj(CConj c) throws InterruptedException {
+            case CConj: { CConj c = (CConj) constraint;
                 return success(c, state, NO_UPDATED_VARS, disjoin(c), NO_NEW_CRITICAL_EDGES, NO_EXISTENTIALS, fuel);
             }
 
-            @Override public Boolean caseEqual(CEqual c) throws InterruptedException {
+            case CEqual: { CEqual c = (CEqual) constraint;
                 final ITerm term1 = c.term1();
                 final ITerm term2 = c.term2();
                 IDebugContext debug = params.debug();
@@ -389,7 +388,7 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseExists(CExists c) throws InterruptedException {
+            case CExists: { CExists c = (CExists) constraint;
                 final Renaming.Builder _existentials = Renaming.builder();
                 IState.Immutable newState = state;
                 for(ITermVar var : c.vars()) {
@@ -412,11 +411,11 @@ class GreedySolver {
                         existentials.asMap(), fuel);
             }
 
-            @Override public Boolean caseFalse(CFalse c) {
+            case CFalse: { CFalse c = (CFalse) constraint;
                 return fail(c);
             }
 
-            @Override public Boolean caseInequal(CInequal c) throws InterruptedException {
+            case CInequal: { CInequal c = (CInequal) constraint;
                 final ITerm term1 = c.term1();
                 final ITerm term2 = c.term2();
                 IDebugContext debug = params.debug();
@@ -442,7 +441,7 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseNew(CNew c) throws InterruptedException {
+            case CNew: { CNew c = (CNew) constraint;
                 IState.Immutable newState = state;
 
                 final ITerm scopeTerm = c.scopeTerm();
@@ -462,7 +461,7 @@ class GreedySolver {
                         NO_EXISTENTIALS, fuel);
             }
 
-            @Override public Boolean caseResolveQuery(IResolveQuery c) throws InterruptedException {
+            case IResolveQuery: { IResolveQuery c = (IResolveQuery) constraint;
                 final QueryFilter filter = c.filter();
                 final QueryMin min = c.min();
                 final ITerm scopeTerm = c.scopeTerm();
@@ -534,7 +533,7 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseTellEdge(CTellEdge c) throws InterruptedException {
+            case CTellEdge: { CTellEdge c = (CTellEdge) constraint;
                 final ITerm sourceTerm = c.sourceTerm();
                 final ITerm label = c.label();
                 final ITerm targetTerm = c.targetTerm();
@@ -565,7 +564,7 @@ class GreedySolver {
                         NO_NEW_CRITICAL_EDGES, NO_EXISTENTIALS, fuel);
             }
 
-            @Override public Boolean caseTermId(CAstId c) throws InterruptedException {
+            case CAstId: { CAstId c = (CAstId) constraint;
                 final ITerm term = c.astTerm();
                 final ITerm idTerm = c.idTerm();
 
@@ -593,7 +592,7 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseTermProperty(CAstProperty c) throws InterruptedException {
+            case CAstProperty: { CAstProperty c = (CAstProperty) constraint;
                 final ITerm idTerm = c.idTerm();
                 final ITerm prop = c.property();
                 final ITerm value = c.value();
@@ -642,12 +641,12 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseTrue(CTrue c) throws InterruptedException {
+            case CTrue: { CTrue c = (CTrue) constraint;
                 return success(c, state, NO_UPDATED_VARS, NO_NEW_CONSTRAINTS, NO_NEW_CRITICAL_EDGES, NO_EXISTENTIALS,
                         fuel);
             }
 
-            @Override public Boolean caseTry(CTry c) throws InterruptedException {
+            case CTry: { CTry c = (CTry) constraint;
                 final IDebugContext debug = params.debug();
                 try {
                     if(Solver.entails(spec, state, c.constraint(), params::isComplete, new NullDebugContext(),
@@ -663,7 +662,7 @@ class GreedySolver {
                 }
             }
 
-            @Override public Boolean caseUser(CUser c) throws InterruptedException {
+            case CUser: { CUser c = (CUser) constraint;
                 final String name = c.name();
                 final List<ITerm> args = c.args();
 
@@ -694,7 +693,9 @@ class GreedySolver {
                         applyResult.criticalEdges(), NO_EXISTENTIALS, fuel);
             }
 
-        });
+        }
+        // N.B. don't use this in default case branch, instead use IDE to catch non-exhaustive switch statements
+        throw new RuntimeException("Missing case for IConstraint subclass/tag");
 
     }
 

--- a/statix.solver/src/main/java/mb/statix/spec/PreSolvedConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/spec/PreSolvedConstraint.java
@@ -446,9 +446,7 @@ public class PreSolvedConstraint implements Serializable {
                     CEqual cequal = (CEqual) c;
                     try {
                         final IUnifier.Immutable result;
-                        if((result =
-                            unifier.unify(cequal.term1(), cequal.term2(), isRigid).orElse(null))
-                            == null) {
+                        if((result = unifier.unify(cequal.term1(), cequal.term2(), isRigid).orElse(null)) == null) {
                             failures.add(cequal.withCause(cause));
                             okay = false;
                             break;
@@ -468,8 +466,7 @@ public class PreSolvedConstraint implements Serializable {
                 }
                 case CExists: {
                     CExists cexists = (CExists) c;
-                    final IRenaming renaming = fresh.apply(
-                        cexists.vars()/*FIXME possible opt: .__retainAll(cexists.constraint().freeVars())*/);
+                    final IRenaming renaming = fresh.apply(cexists.vars()/*FIXME possible opt: .__retainAll(cexists.constraint().freeVars())*/);
                     if(first.get()) {
                         existentials.putAll(renaming.asMap());
                     }
@@ -488,8 +485,7 @@ public class PreSolvedConstraint implements Serializable {
                 case CInequal: {
                     CInequal cinequal = (CInequal) c;
                     try {
-                        if(!unifier.disunify(cinequal.universals(), cinequal.term1(),
-                            cinequal.term2(), isRigid).isPresent()) {
+                        if(!unifier.disunify(cinequal.universals(), cinequal.term1(), cinequal.term2(), isRigid).isPresent()) {
                             failures.add(cinequal.withCause(cause));
                             okay = false;
                             break;

--- a/statix.solver/src/main/java/mb/statix/spec/PreSolvedConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/spec/PreSolvedConstraint.java
@@ -36,8 +36,11 @@ import mb.nabl2.terms.unification.u.IUnifier;
 import mb.nabl2.terms.unification.ud.IUniDisunifier;
 import mb.nabl2.terms.unification.ud.PersistentUniDisunifier;
 import mb.nabl2.util.TermFormatter;
+import mb.statix.constraints.CConj;
+import mb.statix.constraints.CEqual;
 import mb.statix.constraints.CExists;
 import mb.statix.constraints.CFalse;
+import mb.statix.constraints.CInequal;
 import mb.statix.constraints.Constraints;
 import mb.statix.solver.Delay;
 import mb.statix.solver.IConstraint;
@@ -432,30 +435,41 @@ public class PreSolvedConstraint implements Serializable {
         AtomicBoolean first = new AtomicBoolean(true);
         while(!worklist.isEmpty()) {
             final IConstraint c = worklist.removeLast();
-            // @formatter:off
-            final boolean okay = c.match(Constraints.<Boolean>cases(
-                carith -> { constraints.add(c.withCause(cause)); return true; },
-                conj   -> { worklist.addAll(Constraints.disjoin(conj)); return true; },
-                cequal -> {
+            boolean okay = true;
+            switch(c.constraintTag()) {
+                case CConj: {
+                    CConj conj = (CConj) c;
+                    worklist.addAll(Constraints.disjoin(conj));
+                    break;
+                }
+                case CEqual: {
+                    CEqual cequal = (CEqual) c;
                     try {
                         final IUnifier.Immutable result;
-                        if((result = unifier.unify(cequal.term1(), cequal.term2(), isRigid).orElse(null)) == null) {
+                        if((result =
+                            unifier.unify(cequal.term1(), cequal.term2(), isRigid).orElse(null))
+                            == null) {
                             failures.add(cequal.withCause(cause));
-                            return false;
+                            okay = false;
+                            break;
                         }
                         updatedVars.addAll(result.domainSet());
                         bodyCriticalEdges.updateAll(result.domainSet(), result);
-                        return true;
+                        break;
                     } catch(OccursException e) {
                         failures.add(cequal.withCause(cause));
-                        return false;
+                        okay = false;
+                        break;
                     } catch(RigidException e) {
                         delays.put(cequal, Delay.ofVars(e.vars()));
-                        return false;
+                        okay = false;
+                        break;
                     }
-                },
-                cexists -> {
-                    final IRenaming renaming = fresh.apply(cexists.vars()/*FIXME possible opt: .__retainAll(cexists.constraint().freeVars())*/);
+                }
+                case CExists: {
+                    CExists cexists = (CExists) c;
+                    final IRenaming renaming = fresh.apply(
+                        cexists.vars()/*FIXME possible opt: .__retainAll(cexists.constraint().freeVars())*/);
                     if(first.get()) {
                         existentials.putAll(renaming.asMap());
                     }
@@ -463,35 +477,46 @@ public class PreSolvedConstraint implements Serializable {
                     cexists.bodyCriticalEdges().ifPresent(bce -> {
                         bodyCriticalEdges.addAll(bce.apply(renaming), unifier);
                     });
-                    return true;
-                },
-                cfalse -> {
+                    break;
+                }
+                case CFalse: {
+                    CFalse cfalse = (CFalse) c;
                     failures.add(cfalse.withCause(cause));
-                    return false;
-                },
-                cinequal  -> {
+                    okay = false;
+                    break;
+                }
+                case CInequal: {
+                    CInequal cinequal = (CInequal) c;
                     try {
-                        if(!unifier.disunify(cinequal.universals(), cinequal.term1(), cinequal.term2(), isRigid).isPresent()) {
+                        if(!unifier.disunify(cinequal.universals(), cinequal.term1(),
+                            cinequal.term2(), isRigid).isPresent()) {
                             failures.add(cinequal.withCause(cause));
-                            return false;
+                            okay = false;
+                            break;
                         }
-                    } catch (RigidException e) {
+                        break;
+                    } catch(RigidException e) {
                         delays.put(cinequal, Delay.ofVars(e.vars()));
-                        return false;
+                        okay = false;
+                        break;
                     }
-                    return true;
-                },
-                cnew      -> { constraints.add(c.withCause(cause)); return true; },
-                cquery    -> { constraints.add(c.withCause(cause)); return true; },
-                ctelledge -> { constraints.add(c.withCause(cause)); return true; },
-                castid    -> { constraints.add(c.withCause(cause)); return true; },
-                castprop  -> { constraints.add(c.withCause(cause)); return true; },
-                ctrue     -> { return true; },
-                ctry      -> { constraints.add(c.withCause(cause)); return true; },
-                cuser     -> { constraints.add(c.withCause(cause)); return true; }
-            ));
+                }
+                case CTrue: {
+                    break;
+                }
+                case CArith:
+                case CNew:
+                case IResolveQuery:
+                case CTellEdge:
+                case CAstId:
+                case CAstProperty:
+                case CTry:
+                case CUser: {
+                    constraints.add(c.withCause(cause));
+                    break;
+                }
+            }
             first.set(false);
-            // @formatter:on
             if(!okay && returnOnFirstErrorOrDelay) {
                 return;
             }

--- a/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
+++ b/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
@@ -43,6 +43,7 @@ import mb.nabl2.terms.substitution.ISubstitution;
 import mb.nabl2.terms.substitution.PersistentSubstitution;
 import mb.nabl2.terms.unification.ud.IUniDisunifier;
 import mb.nabl2.util.TermFormatter;
+import mb.statix.constraints.CUser;
 import mb.statix.constraints.Constraints;
 import mb.statix.constraints.messages.IMessage;
 import mb.statix.solver.IConstraint;
@@ -236,27 +237,13 @@ public abstract class StatixPrimitive extends AbstractPrimitive {
     }
 
     private static Optional<ITerm> findOriginArgument(IConstraint constraint, IUniDisunifier unifier) {
-        // @formatter:off
-        final Function1<IConstraint, Stream<ITerm>> terms = Constraints.cases(
-            onArith -> Stream.empty(),
-            onConj -> Stream.empty(),
-            onEqual -> Stream.empty(),
-            onExists -> Stream.empty(),
-            onFalse -> Stream.empty(),
-            onInequal -> Stream.empty(),
-            onNew -> Stream.empty(),
-            onResolveQuery -> Stream.empty(),
-            onTellEdge -> Stream.empty(),
-            onTermId -> Stream.empty(),
-            onTermProperty -> Stream.empty(),
-            onTrue -> Stream.empty(),
-            onTry -> Stream.empty(),
-            onUser -> onUser.args().stream()
-        );
-        return terms.apply(constraint)
+        if(constraint.constraintTag() == IConstraint.Tag.CUser) {
+            CUser onUser = (CUser) constraint;
+            onUser.args().stream()
                 .flatMap(t -> Streams.stream(getOriginTerm(t, unifier)))
                 .findFirst();
-        // @formatter:on
+        }
+        return Optional.empty();
     }
 
     private static Optional<ITerm> getOriginTerm(ITerm term, IUniDisunifier unifier) {

--- a/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
+++ b/statix.solver/src/main/java/mb/statix/spoofax/StatixPrimitive.java
@@ -239,7 +239,7 @@ public abstract class StatixPrimitive extends AbstractPrimitive {
     private static Optional<ITerm> findOriginArgument(IConstraint constraint, IUniDisunifier unifier) {
         if(constraint.constraintTag() == IConstraint.Tag.CUser) {
             CUser onUser = (CUser) constraint;
-            onUser.args().stream()
+            return onUser.args().stream()
                 .flatMap(t -> Streams.stream(getOriginTerm(t, unifier)))
                 .findFirst();
         }


### PR DESCRIPTION
I had a look at the `Cases` pattern in the `statix.solver` project and tried replacing it with switch statements. This seems to work out alright, doesn't gives much more ugly code (some cases I'd argue the code even gets better), and should be somewhat faster I think. Can you try running your benchmark/profiling example on this version and see if it makes a difference in performance? This doesn't get rid of all the lambdas, but it should help I think/hope.