### PR TITLE
Remove `signatures/-` import in `renaming.str`.

### DIFF
--- a/statix.runtime/trans/statix/runtime/renaming.str
+++ b/statix.runtime/trans/statix/runtime/renaming.str
@@ -2,7 +2,6 @@ module statix/runtime/renaming
 
 imports
     libstratego-lib
-  signatures/-
     libspoofax/analysis/constraint
     libspoofax/ui/dialogs
     statix/runtime/analysis

--- a/statix.runtime/trans/statix/runtime/renaming.str2
+++ b/statix.runtime/trans/statix/runtime/renaming.str2
@@ -2,7 +2,6 @@ module statix/runtime/renaming
 
 imports
     strategolib
-  signatures/-
     libspoofax/analysis/constraint
     libspoofax/ui/dialogs
     statix/runtime/analysis


### PR DESCRIPTION
`statix.runtime/trans/statix/runtime/renaming.str` imports `signatures/-`, but this import can fail when `statix.runtime` is used through a source dependency, because only `signatures/statix/**/*.str` is exported from `src-gen`. If the language itself then does not have any generated signatures in the `signatures` directory, the import will fail. This is observed in Spoofax 3 through https://github.com/metaborg/spoofax-pie/issues/112.

I think the export is correct and `renaming.str` should not import `signatures/-`, which seems to not be needed anyway, and that is what this PR changes.