### PR TITLE
Add origin field to constraints

### DIFF
--- a/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
+++ b/statix.generator/src/main/java/mb/statix/generator/strategy/Expand.java
@@ -68,7 +68,7 @@ public final class Expand extends SearchStrategy<FocusedSearchState<CUser>, Sear
         final java.util.Map<Rule, Double> rules = getWeightedRules(ctx, predicate.name());
         // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
         final List<Tuple2<Rule, ApplyResult>> results = RuleUtil.applyAll(input.state().unifier(), rules.keySet(),
-                predicate.args(), predicate, ApplyMode.RELAXED, Safety.UNSAFE);
+                predicate.args(), predicate, ApplyMode.RELAXED, Safety.UNSAFE, false);
 
         final List<Pair<SearchNode<SearchState>, Double>> newNodes = new ArrayList<>();
         results.forEach(result -> {

--- a/statix.solver/src/main/java/mb/statix/concurrent/AbstractTypeChecker.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/AbstractTypeChecker.java
@@ -166,23 +166,29 @@ public abstract class AbstractTypeChecker<R extends ITypeChecker.IOutput<Scope, 
 
     protected IFuture<SolverResult> runSolver(ITypeCheckerContext<Scope, ITerm, ITerm> context, Optional<Rule> rule,
             List<Scope> scopes) {
-        if(!rule.isPresent()) {
-            for(Scope scope : scopes) {
+        if (!rule.isPresent()) {
+            for (Scope scope : scopes) {
                 context.initScope(scope, Collections.emptyList(), false);
             }
             return CompletableFuture.completedFuture(SolverResult.of(spec));
         }
-        final /*IState.*/Immutable unitState = State.of().withResource(context.id());
         final ApplyResult applyResult;
         try {
             // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-            if((applyResult =
-                    RuleUtil.apply(unitState.unifier(), rule.get(), scopes, null, ApplyMode.STRICT, Safety.UNSAFE)
-                            .orElse(null)) == null) {
+            applyResult = RuleUtil.apply(
+                    unitState.unifier(),
+                    rule.get(),
+                    scopes,
+                    null,
+                    ApplyMode.STRICT,
+                    Safety.UNSAFE,
+                    true
+            ).orElse(null);
+            if (applyResult == null) {
                 return CompletableFuture.completedExceptionally(
                         new IllegalArgumentException("Cannot apply initial rule to root scope."));
             }
-        } catch(Delay delay) {
+        } catch (Delay delay) {
             return CompletableFuture.completedExceptionally(
                     new IllegalArgumentException("Cannot apply initial rule to root scope.", delay));
         }

--- a/statix.solver/src/main/java/mb/statix/concurrent/AbstractTypeChecker.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/AbstractTypeChecker.java
@@ -172,6 +172,7 @@ public abstract class AbstractTypeChecker<R extends ITypeChecker.IOutput<Scope, 
             }
             return CompletableFuture.completedFuture(SolverResult.of(spec));
         }
+        final /*IState.*/Immutable unitState = State.of().withResource(context.id());
         final ApplyResult applyResult;
         try {
             // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty

--- a/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
@@ -855,7 +855,7 @@ public class StatixSolver {
                 final ImList.Immutable<Rule> rules = spec.rules().getRules(name);
                 // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
                 final Tuple3<Rule, ApplyResult, Boolean> result;
-                if((result = RuleUtil.applyOrderedOne(state.unifier(), rules, args, c, ApplyMode.RELAXED, Safety.UNSAFE)
+                if((result = RuleUtil.applyOrderedOne(state.unifier(), rules, args, c, ApplyMode.RELAXED, Safety.UNSAFE, true)
                         .orElse(null)) == null) {
                     debug.debug("No rule applies");
                     return fail(c);

--- a/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
@@ -559,7 +559,7 @@ public class StatixSolver {
                 final Renaming existentials = _existentials.build();
 
                 final ISubstitution.Immutable subst = existentials.asSubstitution();
-                final IConstraint newConstraint = c.constraint().apply(subst).withCause(c.cause().orElse(null));
+                final IConstraint newConstraint = c.constraint().apply(subst, true).withCause(c.cause().orElse(null));
                 if(INCREMENTAL_CRITICAL_EDGES && !c.bodyCriticalEdges().isPresent()) {
                     throw new IllegalArgumentException(
                             "Solver only accepts constraints with pre-computed critical edges.");

--- a/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
+++ b/statix.solver/src/main/java/mb/statix/concurrent/StatixSolver.java
@@ -314,8 +314,16 @@ public class StatixSolver {
         final io.usethesource.capsule.Map.Immutable<ITermVar, ITermVar> existentials = Optional.ofNullable(this.existentials).orElse(NO_EXISTENTIALS);
         final Set.Immutable<CriticalEdge> removedEdges = CapsuleUtil.immutableSet();
         final ICompleteness.Immutable completeness = Completeness.Immutable.of();
-        final SolverResult result =
-                SolverResult.of(spec, state, failed(), delayed, existentials, updatedVars(), removedEdges, completeness);
+        final SolverResult result = SolverResult.of(
+                spec,
+                state,
+                failed(),
+                delayed,
+                existentials,
+                updatedVars(),
+                removedEdges,
+                completeness
+        );
         return result;
     }
 
@@ -1123,14 +1131,22 @@ public class StatixSolver {
             try {
                 final ApplyResult applyResult;
                 // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                if((applyResult = RuleUtil.apply(state.unifier(), constraint, ImList.Immutable.of(datum), null,
-                        ApplyMode.STRICT, Safety.UNSAFE).orElse(null)) == null) {
+                applyResult = RuleUtil.apply(
+                        state.unifier(),
+                        constraint,
+                        ImList.Immutable.of(datum),
+                        null,
+                        ApplyMode.STRICT,
+                        Safety.UNSAFE,
+                        true
+                ).orElse(null);
+                if (applyResult == null) {
                     return CompletableFuture.completedFuture(false);
                 }
 
                 return entails(context, spec, state, applyResult.body(), applyResult.criticalEdges(),
                         new NullDebugContext(), cancel, new NullProgress());
-            } catch(Delay e) {
+            } catch (Delay e) {
                 throw new IllegalStateException("Unexpected delay.", e);
             }
         }
@@ -1209,10 +1225,17 @@ public class StatixSolver {
                 ICancel cancel) throws InterruptedException {
             return absorbDelays(() -> {
                 try {
-                    final ApplyResult applyResult;
                     // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                    if((applyResult = RuleUtil.apply(state.unifier(), constraint, ImList.Immutable.of(datum), null,
-                            ApplyMode.STRICT, Safety.UNSAFE).orElse(null)) == null) {
+                    final ApplyResult applyResult = RuleUtil.apply(
+                            state.unifier(),
+                            constraint,
+                            ImList.Immutable.of(datum),
+                            null,
+                            ApplyMode.STRICT,
+                            Safety.UNSAFE,
+                            true
+                    ).orElse(null);
+                    if(applyResult == null) {
                         return CompletableFuture.completedFuture(false);
                     }
 
@@ -1248,16 +1271,23 @@ public class StatixSolver {
         @Override public IFuture<Boolean> leq(ITerm datum1, ITerm datum2,
                 ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) throws InterruptedException {
             try {
-                final ApplyResult applyResult;
                 // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                if((applyResult = RuleUtil.apply(state.unifier(), constraint, ImList.Immutable.of(datum1, datum2), null,
-                        ApplyMode.STRICT, Safety.UNSAFE).orElse(null)) == null) {
+                final ApplyResult applyResult = RuleUtil.apply(
+                        state.unifier(),
+                        constraint,
+                        ImList.Immutable.of(datum1, datum2),
+                        null,
+                        ApplyMode.STRICT,
+                        Safety.UNSAFE,
+                        true
+                ).orElse(null);
+                if (applyResult == null) {
                     return CompletableFuture.completedFuture(false);
                 }
 
                 return entails(context, spec, state, applyResult.body(), applyResult.criticalEdges(),
                         new NullDebugContext(), cancel, new NullProgress());
-            } catch(Delay e) {
+            } catch (Delay e) {
                 throw new IllegalStateException("Unexpected delay.", e);
             }
         }
@@ -1265,12 +1295,12 @@ public class StatixSolver {
         private transient @Nullable IFuture<Boolean> alwaysTrue;
 
         @Override public IFuture<Boolean> alwaysTrue(ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) {
-            if(alwaysTrue == null) {
+            if (alwaysTrue == null) {
                 try {
-                    switch(SHADOW_OPTIMIZATION) {
+                    switch (SHADOW_OPTIMIZATION) {
                         case CONTEXT:
                             final Boolean isAlways;
-                            if((isAlways = constraint.isAlways().orElse(null)) != null) {
+                            if ((isAlways = constraint.isAlways().orElse(null)) != null) {
                                 alwaysTrue = CompletableFuture.completedFuture(isAlways);
                             } else {
                                 final ApplyResult result;
@@ -1280,16 +1310,23 @@ public class StatixSolver {
                                         d1_state._2().freshVar(B.newVar(state.resource(), "d2"));
                                 try {
                                     // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                                    if((result = RuleUtil.apply(d2_state._2().unifier(), constraint,
-                                            ImList.Immutable.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT,
-                                            Safety.UNSAFE).orElse(null)) == null) {
+                                    result = RuleUtil.apply(
+                                            d2_state._2().unifier(),
+                                            constraint,
+                                            ImList.Immutable.of(d1_state._1(), d2_state._1()),
+                                            null,
+                                            ApplyMode.STRICT,
+                                            Safety.UNSAFE,
+                                            true
+                                    ).orElse(null);
+                                    if (result == null) {
                                         alwaysTrue = CompletableFuture.completedFuture(false);
                                     } else {
                                         alwaysTrue = entails(context, spec, d2_state._2(), result.body(),
                                                 result.criticalEdges(), new NullDebugContext(), cancel,
                                                 new NullProgress());
                                     }
-                                } catch(Delay e) {
+                                } catch (Delay e) {
                                     throw new IllegalStateException("Unexpected delay.", e);
                                 }
                             }
@@ -1302,7 +1339,7 @@ public class StatixSolver {
                             alwaysTrue = CompletableFuture.completedFuture(false);
                             break;
                     }
-                } catch(InterruptedException e) {
+                } catch (InterruptedException e) {
                     return CompletableFuture.completedExceptionally(e);
                 }
             }
@@ -1364,15 +1401,22 @@ public class StatixSolver {
                 ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) throws InterruptedException {
             return absorbDelays(() -> {
                 try {
-                    final ApplyResult applyResult;
                     // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                    if((applyResult = RuleUtil.apply(state.unifier(), constraint, ImList.Immutable.of(datum1, datum2),
-                            null, ApplyMode.STRICT, Safety.UNSAFE).orElse(null)) == null) {
+                    final ApplyResult applyResult = RuleUtil.apply(
+                            state.unifier(),
+                            constraint,
+                            ImList.Immutable.of(datum1, datum2),
+                            null,
+                            ApplyMode.STRICT,
+                            Safety.UNSAFE,
+                            true
+                    ).orElse(null);
+                    if (applyResult == null) {
                         return CompletableFuture.completedFuture(false);
                     }
 
                     return entails(context, applyResult.body(), applyResult.criticalEdges(), cancel);
-                } catch(Delay delay) {
+                } catch (Delay delay) {
                     return CompletableFuture.completedExceptionally(delay);
                 }
             });
@@ -1381,30 +1425,37 @@ public class StatixSolver {
         private transient @Nullable IFuture<Boolean> alwaysTrue;
 
         @Override public IFuture<Boolean> alwaysTrue(ITypeCheckerContext<Scope, ITerm, ITerm> context, ICancel cancel) {
-            if(alwaysTrue == null) {
+            if (alwaysTrue == null) {
                 try {
-                    switch(SHADOW_OPTIMIZATION) {
+                    switch (SHADOW_OPTIMIZATION) {
                         case CONTEXT:
                             final Boolean isAlways;
-                            if((isAlways = constraint.isAlways().orElse(null)) != null) {
+                            if ((isAlways = constraint.isAlways().orElse(null)) != null) {
                                 alwaysTrue = CompletableFuture.completedFuture(isAlways);
                             } else {
                                 alwaysTrue = absorbDelays(() -> {
                                     try {
-                                        final ApplyResult result;
+
                                         final Tuple2<ITermVar, IState.Immutable> d1_state =
                                                 state.freshVar(B.newVar(state.resource(), "d1"));
                                         final Tuple2<ITermVar, IState.Immutable> d2_state =
                                                 d1_state._2().freshVar(B.newVar(state.resource(), "d2"));
                                         // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-                                        if((result = RuleUtil.apply(d2_state._2().unifier(), constraint,
-                                                ImList.Immutable.of(d1_state._1(), d2_state._1()), null, ApplyMode.STRICT,
-                                                Safety.UNSAFE).orElse(null)) == null) {
+                                        final ApplyResult result = RuleUtil.apply(
+                                                d2_state._2().unifier(),
+                                                constraint,
+                                                ImList.Immutable.of(d1_state._1(), d2_state._1()),
+                                                null,
+                                                ApplyMode.STRICT,
+                                                Safety.UNSAFE,
+                                                true
+                                        ).orElse(null);
+                                        if (result == null) {
                                             return CompletableFuture.completedFuture(false);
                                         }
                                         return entails(context, spec, state, result.body(), result.criticalEdges(),
                                                 new NullDebugContext(), cancel, new NullProgress());
-                                    } catch(Delay delay) {
+                                    } catch (Delay delay) {
                                         return CompletableFuture.completedExceptionally(delay);
                                     }
                                 });
@@ -1418,7 +1469,7 @@ public class StatixSolver {
                             alwaysTrue = CompletableFuture.completedFuture(false);
                             break;
                     }
-                } catch(InterruptedException e) {
+                } catch (InterruptedException e) {
                     return CompletableFuture.completedExceptionally(e);
                 }
             }

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -126,6 +126,18 @@ public final class CArith implements IConstraint, Serializable {
         }
     }
 
+    @Override public CArith apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CArith unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CArith apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CArith apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CArith(
                 expr1.apply(subst),

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -70,6 +70,14 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     public CArith withArguments(ArithExpr expr1, ArithTest op, ArithExpr expr2) {
+        if (this.expr1 == expr1 &&
+            this.op == op &&
+            this.expr2 == expr2
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CArith(expr1, op, expr2, cause, message, origin);
     }
 
@@ -78,6 +86,11 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     @Override public CArith withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CArith(expr1, op, expr2, cause, message, origin);
     }
 
@@ -86,6 +99,11 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     @Override public CArith withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CArith(expr1, op, expr2, cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -29,14 +29,15 @@ public final class CArith implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CArith origin;
 
     public CArith(ArithExpr expr1, ArithTest op, ArithExpr expr2) {
-        this(expr1, op, expr2, null, null);
+        this(expr1, op, expr2, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
     public CArith(ArithExpr expr1, ArithTest op, ArithExpr expr2, @Nullable IMessage message) {
-        this(expr1, op, expr2, null, message);
+        this(expr1, op, expr2, null, message, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -45,13 +46,15 @@ public final class CArith implements IConstraint, Serializable {
             ArithTest op,
             ArithExpr expr2,
             @Nullable IConstraint cause,
-            @Nullable IMessage message
+            @Nullable IMessage message,
+            @Nullable CArith origin
     ) {
         this.expr1 = expr1;
         this.op = op;
         this.expr2 = expr2;
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
     }
 
     public ArithExpr expr1() {
@@ -67,7 +70,7 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     public CArith withArguments(ArithExpr expr1, ArithTest op, ArithExpr expr2) {
-        return new CArith(expr1, op, expr2, cause, message);
+        return new CArith(expr1, op, expr2, cause, message, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -75,7 +78,7 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     @Override public CArith withCause(@Nullable IConstraint cause) {
-        return new CArith(expr1, op, expr2, cause, message);
+        return new CArith(expr1, op, expr2, cause, message, origin);
     }
 
     @Override public Optional<IMessage> message() {
@@ -83,7 +86,11 @@ public final class CArith implements IConstraint, Serializable {
     }
 
     @Override public CArith withMessage(@Nullable IMessage message) {
-        return new CArith(expr1, op, expr2, cause, message);
+        return new CArith(expr1, op, expr2, cause, message, origin);
+    }
+
+    @Override public @Nullable CArith origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -125,7 +132,8 @@ public final class CArith implements IConstraint, Serializable {
                 op,
                 expr2.apply(subst),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -139,7 +147,8 @@ public final class CArith implements IConstraint, Serializable {
                 op,
                 expr2.apply(subst),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -167,7 +176,8 @@ public final class CArith implements IConstraint, Serializable {
             && Objects.equals(this.op, that.op)
             && Objects.equals(this.expr2, that.expr2)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -183,7 +193,8 @@ public final class CArith implements IConstraint, Serializable {
                 op,
                 expr2,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CArith.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CArith.java
@@ -126,29 +126,29 @@ public final class CArith implements IConstraint, Serializable {
         }
     }
 
-    @Override public CArith apply(ISubstitution.Immutable subst) {
+    @Override public CArith apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CArith(
                 expr1.apply(subst),
                 op,
                 expr2.apply(subst),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CArith unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CArith unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CArith apply(IRenaming subst) {
+    @Override public CArith apply(IRenaming subst, boolean trackOrigin) {
         return new CArith(
                 expr1.apply(subst),
                 op,
                 expr2.apply(subst),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -47,6 +47,13 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     public CAstId withArguments(ITerm term, ITerm idTerm) {
+        if (this.term == term &&
+            this.idTerm == idTerm
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CAstId(term, idTerm, cause, origin);
     }
 
@@ -55,6 +62,11 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     @Override public CAstId withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CAstId(term, idTerm, cause, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -92,16 +92,26 @@ public final class CAstId implements IConstraint, Serializable {
         idTerm.getVars().forEach(onFreeVar::apply);
     }
 
-    @Override public CAstId apply(ISubstitution.Immutable subst) {
-        return new CAstId(subst.apply(term), subst.apply(idTerm), cause, origin);
+    @Override public CAstId apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CAstId(
+                subst.apply(term),
+                subst.apply(idTerm),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CAstId unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CAstId unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CAstId apply(IRenaming subst) {
-        return new CAstId(subst.apply(term), subst.apply(idTerm), cause, origin);
+    @Override public CAstId apply(IRenaming subst, boolean trackOrigin) {
+        return new CAstId(
+                subst.apply(term),
+                subst.apply(idTerm),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
     @Override public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -92,6 +92,18 @@ public final class CAstId implements IConstraint, Serializable {
         idTerm.getVars().forEach(onFreeVar::apply);
     }
 
+    @Override public CAstId apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CAstId unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CAstId apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CAstId apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CAstId(
                 subst.apply(term),

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstId.java
@@ -24,16 +24,18 @@ public final class CAstId implements IConstraint, Serializable {
     private final ITerm idTerm;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CAstId origin;
 
     public CAstId(ITerm term, ITerm idTerm) {
-        this(term, idTerm, null);
+        this(term, idTerm, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
-    private CAstId(ITerm term, ITerm idTerm, @Nullable IConstraint cause) {
+    private CAstId(ITerm term, ITerm idTerm, @Nullable IConstraint cause, @Nullable CAstId origin) {
         this.term = term;
         this.idTerm = idTerm;
         this.cause = cause;
+        this.origin = origin;
     }
 
     public ITerm astTerm() {
@@ -45,7 +47,7 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     public CAstId withArguments(ITerm term, ITerm idTerm) {
-        return new CAstId(term, idTerm, cause);
+        return new CAstId(term, idTerm, cause, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -53,7 +55,11 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     @Override public CAstId withCause(@Nullable IConstraint cause) {
-        return new CAstId(term, idTerm, cause);
+        return new CAstId(term, idTerm, cause, origin);
+    }
+
+    @Override public @Nullable CAstId origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -87,7 +93,7 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     @Override public CAstId apply(ISubstitution.Immutable subst) {
-        return new CAstId(subst.apply(term), subst.apply(idTerm), cause);
+        return new CAstId(subst.apply(term), subst.apply(idTerm), cause, origin);
     }
 
     @Override public CAstId unsafeApply(ISubstitution.Immutable subst) {
@@ -95,7 +101,7 @@ public final class CAstId implements IConstraint, Serializable {
     }
 
     @Override public CAstId apply(IRenaming subst) {
-        return new CAstId(subst.apply(term), subst.apply(idTerm), cause);
+        return new CAstId(subst.apply(term), subst.apply(idTerm), cause, origin);
     }
 
     @Override public String toString(TermFormatter termToString) {
@@ -122,7 +128,8 @@ public final class CAstId implements IConstraint, Serializable {
         return this.hashCode == that.hashCode
             && Objects.equals(this.term, that.term)
             && Objects.equals(this.idTerm, that.idTerm)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -136,7 +143,8 @@ public final class CAstId implements IConstraint, Serializable {
         return Objects.hash(
                 term,
                 idTerm,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -79,6 +79,15 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     public CAstProperty withArguments(ITerm idTerm, ITerm property, Op op, ITerm value) {
+        if (this.idTerm == idTerm &&
+            this.property == property &&
+            this.op == op &&
+            this.value == value
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CAstProperty(idTerm, property, op, value, cause, origin);
     }
 
@@ -87,6 +96,11 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     @Override public CAstProperty withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CAstProperty(idTerm, property, op, value, cause, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -39,9 +39,10 @@ public final class CAstProperty implements IConstraint, Serializable {
     private final ITerm value;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CAstProperty origin;
 
     public CAstProperty(ITerm idTerm, ITerm property, Op op, ITerm value) {
-        this(idTerm, property, op, value, null);
+        this(idTerm, property, op, value, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -50,13 +51,15 @@ public final class CAstProperty implements IConstraint, Serializable {
             ITerm property,
             Op op,
             ITerm value,
-            @Nullable IConstraint cause
+            @Nullable IConstraint cause,
+            @Nullable CAstProperty origin
     ) {
         this.idTerm = idTerm;
         this.property = property;
         this.op = op;
         this.value = value;
         this.cause = cause;
+        this.origin = origin;
     }
 
     public ITerm idTerm() {
@@ -76,7 +79,7 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     public CAstProperty withArguments(ITerm idTerm, ITerm property, Op op, ITerm value) {
-        return new CAstProperty(idTerm, property, op, value, cause);
+        return new CAstProperty(idTerm, property, op, value, cause, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -84,7 +87,11 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     @Override public CAstProperty withCause(@Nullable IConstraint cause) {
-        return new CAstProperty(idTerm, property, op, value, cause);
+        return new CAstProperty(idTerm, property, op, value, cause, origin);
+    }
+
+    @Override public @Nullable CAstProperty origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -118,7 +125,7 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     @Override public CAstProperty apply(ISubstitution.Immutable subst) {
-        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause);
+        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause, origin);
     }
 
     @Override public CAstProperty unsafeApply(ISubstitution.Immutable subst) {
@@ -126,7 +133,7 @@ public final class CAstProperty implements IConstraint, Serializable {
     }
 
     @Override public CAstProperty apply(IRenaming subst) {
-        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause);
+        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause, origin);
     }
 
     @Override public String toString(TermFormatter termToString) {
@@ -156,7 +163,8 @@ public final class CAstProperty implements IConstraint, Serializable {
             && Objects.equals(this.property, that.property)
             && this.op == that.op
             && Objects.equals(this.value, that.value)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -172,7 +180,8 @@ public final class CAstProperty implements IConstraint, Serializable {
                 property,
                 op,
                 value,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -124,16 +124,30 @@ public final class CAstProperty implements IConstraint, Serializable {
         value.getVars().forEach(onFreeVar::apply);
     }
 
-    @Override public CAstProperty apply(ISubstitution.Immutable subst) {
-        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause, origin);
+    @Override public CAstProperty apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CAstProperty(
+                subst.apply(idTerm),
+                property,
+                op,
+                subst.apply(value),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CAstProperty unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CAstProperty unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CAstProperty apply(IRenaming subst) {
-        return new CAstProperty(subst.apply(idTerm), property, op, subst.apply(value), cause, origin);
+    @Override public CAstProperty apply(IRenaming subst, boolean trackOrigin) {
+        return new CAstProperty(
+                subst.apply(idTerm),
+                property,
+                op,
+                subst.apply(value),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
     @Override public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CAstProperty.java
@@ -124,6 +124,18 @@ public final class CAstProperty implements IConstraint, Serializable {
         value.getVars().forEach(onFreeVar::apply);
     }
 
+    @Override public CAstProperty apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CAstProperty unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CAstProperty apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CAstProperty apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CAstProperty(
                 subst.apply(idTerm),

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -107,7 +107,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
         );
     }
 
-    @Override public CCompiledQuery apply(Immutable subst) {
+    @Override public CCompiledQuery apply(Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
                 filter.apply(subst),
                 min.apply(subst),
@@ -116,12 +116,12 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 stateMachine
         );
     }
 
-    @Override public CCompiledQuery unsafeApply(Immutable subst) {
+    @Override public CCompiledQuery unsafeApply(Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
                 filter.unsafeApply(subst),
                 min.unsafeApply(subst),
@@ -130,12 +130,12 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 stateMachine
         );
     }
 
-    @Override public CCompiledQuery apply(IRenaming subst) {
+    @Override public CCompiledQuery apply(IRenaming subst, boolean trackOrigin) {
         return new CCompiledQuery(
                 filter.apply(subst),
                 min.apply(subst),
@@ -144,7 +144,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 stateMachine
         );
     }

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -138,8 +138,8 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
 
     @Override public CCompiledQuery apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
-                filter.apply(subst),
-                min.apply(subst),
+                filter.apply(subst, trackOrigin),
+                min.apply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
@@ -152,8 +152,8 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
 
     @Override public CCompiledQuery unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
-                filter.unsafeApply(subst),
-                min.unsafeApply(subst),
+                filter.unsafeApply(subst, trackOrigin),
+                min.unsafeApply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
@@ -166,8 +166,8 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
 
     @Override public CCompiledQuery apply(IRenaming subst, boolean trackOrigin) {
         return new CCompiledQuery(
-                filter.apply(subst),
-                min.apply(subst),
+                filter.apply(subst, trackOrigin),
+                min.apply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -66,10 +66,6 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
         this.stateMachine = stateMachine;
     }
 
-    public CCompiledQuery withArguments(QueryFilter filter, QueryMin min, QueryProject project, ITerm scopeTerm, ITerm resultTerm) {
-        return withArguments(filter, min, project, scopeTerm, resultTerm, this.stateMachine);
-    }
-
     public CCompiledQuery withArguments(
             QueryFilter filter,
             QueryMin min,

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 
 import mb.nabl2.terms.ITerm;
 import mb.nabl2.terms.substitution.IRenaming;
+import mb.nabl2.terms.substitution.ISubstitution;
 import mb.nabl2.terms.substitution.ISubstitution.Immutable;
 import mb.nabl2.util.TermFormatter;
 import mb.scopegraph.oopsla20.reference.ResolutionException;
@@ -107,7 +108,19 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
         );
     }
 
-    @Override public CCompiledQuery apply(Immutable subst, boolean trackOrigin) {
+    @Override public CCompiledQuery apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CCompiledQuery unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CCompiledQuery apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CCompiledQuery apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
                 filter.apply(subst),
                 min.apply(subst),
@@ -121,7 +134,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
         );
     }
 
-    @Override public CCompiledQuery unsafeApply(Immutable subst, boolean trackOrigin) {
+    @Override public CCompiledQuery unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CCompiledQuery(
                 filter.unsafeApply(subst),
                 min.unsafeApply(subst),

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -74,6 +74,17 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             ITerm resultTerm,
             StateMachine<ITerm> stateMachine
     ) {
+        if (this.filter == filter &&
+            this.min == min &&
+            this.project == project &&
+            this.scopeTerm == scopeTerm &&
+            this.resultTerm == resultTerm &&
+            this.stateMachine == stateMachine
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CCompiledQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin, stateMachine);
     }
 
@@ -95,6 +106,11 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
     }
 
     @Override public CCompiledQuery withCause(IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CCompiledQuery(
                 filter,
                 min,

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -66,6 +66,10 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
         this.stateMachine = stateMachine;
     }
 
+    public CCompiledQuery withArguments(QueryFilter filter, QueryMin min, QueryProject project, ITerm scopeTerm, ITerm resultTerm) {
+        return withArguments(filter, min, project, scopeTerm, resultTerm, this.stateMachine);
+    }
+
     public CCompiledQuery withArguments(
             QueryFilter filter,
             QueryMin min,

--- a/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CCompiledQuery.java
@@ -22,6 +22,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
     private static final long serialVersionUID = 1L;
 
     private final StateMachine<ITerm> stateMachine;
+    private final @Nullable CCompiledQuery origin;
 
     public CCompiledQuery(
             QueryFilter filter,
@@ -31,7 +32,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             ITerm resultTerm,
             StateMachine<ITerm> stateMachine
     ) {
-        this(filter, min, project, scopeTerm, resultTerm, null, null, stateMachine);
+        this(filter, min, project, scopeTerm, resultTerm, null, null, null, stateMachine);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
@@ -44,7 +45,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             @Nullable IMessage message,
             StateMachine<ITerm> stateMachine
     ) {
-        this(filter, min, project, scopeTerm, resultTerm, null, message, stateMachine);
+        this(filter, min, project, scopeTerm, resultTerm, null, message, null, stateMachine);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -56,9 +57,11 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             ITerm resultTerm,
             @Nullable IConstraint cause,
             @Nullable IMessage message,
+            @Nullable CCompiledQuery origin,
             StateMachine<ITerm> stateMachine
     ) {
         super(filter, min, project, scopeTerm, resultTerm, cause, message);
+        this.origin = origin;
         this.stateMachine = stateMachine;
     }
 
@@ -70,7 +73,11 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             ITerm resultTerm,
             StateMachine<ITerm> stateMachine
     ) {
-        return new CCompiledQuery(filter, min, project, scopeTerm, resultTerm, cause, message, stateMachine);
+        return new CCompiledQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin, stateMachine);
+    }
+
+    @Override public @Nullable CCompiledQuery origin() {
+        return origin;
     }
 
     public StateMachine<ITerm> stateMachine() {
@@ -95,6 +102,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 resultTerm,
                 cause,
                 message,
+                origin,
                 stateMachine
         );
     }
@@ -108,6 +116,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
+                origin,
                 stateMachine
         );
     }
@@ -121,6 +130,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
+                origin,
                 stateMachine
         );
     }
@@ -134,6 +144,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
+                origin,
                 stateMachine
         );
     }
@@ -168,6 +179,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
             && Objects.equals(this.resultTerm, that.resultTerm)
             && Objects.equals(this.cause, that.cause)
             && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin)
             && Objects.equals(this.stateMachine, that.stateMachine);
         // @formatter:on
     }
@@ -187,6 +199,7 @@ public final class CCompiledQuery extends AResolveQuery implements Serializable 
                 resultTerm,
                 cause,
                 message,
+                origin,
                 stateMachine
         );
     }

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -97,16 +97,31 @@ public final class CConj implements IConstraint, Serializable {
         right.visitFreeVars(onFreeVar);
     }
 
-    @Override public CConj apply(ISubstitution.Immutable subst) {
-        return new CConj(left.apply(subst), right.apply(subst), cause, origin);
+    @Override public CConj apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CConj(
+                left.apply(subst),
+                right.apply(subst),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CConj unsafeApply(ISubstitution.Immutable subst) {
-        return new CConj(left.unsafeApply(subst), right.unsafeApply(subst), cause, origin);
+    @Override public CConj unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CConj(
+                left.unsafeApply(subst),
+                right.unsafeApply(subst),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CConj apply(IRenaming subst) {
-        return new CConj(left.apply(subst), right.apply(subst), cause, origin);
+    @Override public CConj apply(IRenaming subst, boolean trackOrigin) {
+        return new CConj(
+                left.apply(subst),
+                right.apply(subst),
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
     @Override public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -24,15 +24,23 @@ public final class CConj implements IConstraint, Serializable {
     private final IConstraint right;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CConj origin;
 
     public CConj(IConstraint left, IConstraint right) {
-        this(left, right, null);
+        this(left, right, null, null);
     }
 
+    // Do not call this constructor. Call withArguments() or withCause() instead.
     public CConj(IConstraint left, IConstraint right, @Nullable IConstraint cause) {
+        this(left, right, cause, null);
+    }
+
+    // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
+    private CConj(IConstraint left, IConstraint right, @Nullable IConstraint cause, @Nullable CConj origin) {
         this.left = left;
         this.right = right;
         this.cause = cause;
+        this.origin = origin;
     }
 
     public IConstraint left() {
@@ -44,7 +52,7 @@ public final class CConj implements IConstraint, Serializable {
     }
 
     public CConj withArguments(IConstraint left, IConstraint right) {
-        return new CConj(left, right, cause);
+        return new CConj(left, right, cause, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -52,7 +60,11 @@ public final class CConj implements IConstraint, Serializable {
     }
 
     @Override public CConj withCause(@Nullable IConstraint cause) {
-        return new CConj(left, right, cause);
+        return new CConj(left, right, cause, origin);
+    }
+
+    @Override public @Nullable CConj origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -86,15 +98,15 @@ public final class CConj implements IConstraint, Serializable {
     }
 
     @Override public CConj apply(ISubstitution.Immutable subst) {
-        return new CConj(left.apply(subst), right.apply(subst), cause);
+        return new CConj(left.apply(subst), right.apply(subst), cause, origin);
     }
 
     @Override public CConj unsafeApply(ISubstitution.Immutable subst) {
-        return new CConj(left.unsafeApply(subst), right.unsafeApply(subst), cause);
+        return new CConj(left.unsafeApply(subst), right.unsafeApply(subst), cause, origin);
     }
 
     @Override public CConj apply(IRenaming subst) {
-        return new CConj(left.apply(subst), right.apply(subst), cause);
+        return new CConj(left.apply(subst), right.apply(subst), cause, origin);
     }
 
     @Override public String toString(TermFormatter termToString) {
@@ -119,7 +131,8 @@ public final class CConj implements IConstraint, Serializable {
         return this.hashCode == that.hashCode
             && Objects.equals(this.left, that.left)
             && Objects.equals(this.right, that.right)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -133,7 +146,8 @@ public final class CConj implements IConstraint, Serializable {
         return Objects.hash(
                 left,
                 right,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -52,6 +52,13 @@ public final class CConj implements IConstraint, Serializable {
     }
 
     public CConj withArguments(IConstraint left, IConstraint right) {
+        if (this.left == left &&
+            this.right == right
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CConj(left, right, cause, origin);
     }
 
@@ -60,6 +67,11 @@ public final class CConj implements IConstraint, Serializable {
     }
 
     @Override public CConj withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CConj(left, right, cause, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -97,6 +97,18 @@ public final class CConj implements IConstraint, Serializable {
         right.visitFreeVars(onFreeVar);
     }
 
+    @Override public CConj apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CConj unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CConj apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CConj apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CConj(
                 left.apply(subst),

--- a/statix.solver/src/main/java/mb/statix/constraints/CConj.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CConj.java
@@ -111,8 +111,8 @@ public final class CConj implements IConstraint, Serializable {
 
     @Override public CConj apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CConj(
-                left.apply(subst),
-                right.apply(subst),
+                left.apply(subst, trackOrigin),
+                right.apply(subst, trackOrigin),
                 cause,
                 origin == null && trackOrigin ? this : origin
         );
@@ -120,8 +120,8 @@ public final class CConj implements IConstraint, Serializable {
 
     @Override public CConj unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CConj(
-                left.unsafeApply(subst),
-                right.unsafeApply(subst),
+                left.unsafeApply(subst, trackOrigin),
+                right.unsafeApply(subst, trackOrigin),
                 cause,
                 origin == null && trackOrigin ? this : origin
         );
@@ -129,8 +129,8 @@ public final class CConj implements IConstraint, Serializable {
 
     @Override public CConj apply(IRenaming subst, boolean trackOrigin) {
         return new CConj(
-                left.apply(subst),
-                right.apply(subst),
+                left.apply(subst, trackOrigin),
+                right.apply(subst, trackOrigin),
                 cause,
                 origin == null && trackOrigin ? this : origin
         );

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -122,6 +122,18 @@ public final class CEqual implements IConstraint, Serializable {
         }
     }
 
+    @Override public CEqual apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CEqual unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CEqual apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CEqual apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CEqual(
                 subst.apply(term1),

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -66,6 +66,13 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     public CEqual withArguments(ITerm term1, ITerm term2) {
+        if (this.term1 == term1 &&
+            this.term2 == term2
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CEqual(term1, term2, cause, message, origin);
     }
 
@@ -74,6 +81,11 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     @Override public CEqual withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CEqual(term1, term2, cause, message, origin);
     }
 
@@ -82,6 +94,11 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     @Override public CEqual withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CEqual(term1, term2, cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -26,19 +26,20 @@ public final class CEqual implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CEqual origin;
 
     public CEqual(ITerm term1, ITerm term2) {
-        this(term1, term2, null, null);
+        this(term1, term2, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
     public CEqual(ITerm term1, ITerm term2, @Nullable IMessage message) {
-        this(term1, term2, null, message);
+        this(term1, term2, null, message, null);
     }
 
     // Do not call this constructor. This is used in the solver. Call withArguments() or withCause() instead.
     public CEqual(ITerm term1, ITerm term2, @Nullable IConstraint cause) {
-        this(term1, term2, cause, null);
+        this(term1, term2, cause, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -46,12 +47,14 @@ public final class CEqual implements IConstraint, Serializable {
             ITerm term1,
             ITerm term2,
             @Nullable IConstraint cause,
-            @Nullable IMessage message
+            @Nullable IMessage message,
+            @Nullable CEqual origin
     ) {
         this.term1 = term1;
         this.term2 = term2;
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
     }
 
     public ITerm term1() {
@@ -63,7 +66,7 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     public CEqual withArguments(ITerm term1, ITerm term2) {
-        return new CEqual(term1, term2, cause, message);
+        return new CEqual(term1, term2, cause, message, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -71,7 +74,7 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     @Override public CEqual withCause(@Nullable IConstraint cause) {
-        return new CEqual(term1, term2, cause, message);
+        return new CEqual(term1, term2, cause, message, origin);
     }
 
     @Override public Optional<IMessage> message() {
@@ -79,7 +82,11 @@ public final class CEqual implements IConstraint, Serializable {
     }
 
     @Override public CEqual withMessage(@Nullable IMessage message) {
-        return new CEqual(term1, term2, cause, message);
+        return new CEqual(term1, term2, cause, message, origin);
+    }
+
+    @Override public @Nullable CEqual origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -120,7 +127,8 @@ public final class CEqual implements IConstraint, Serializable {
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -133,7 +141,8 @@ public final class CEqual implements IConstraint, Serializable {
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -160,7 +169,8 @@ public final class CEqual implements IConstraint, Serializable {
             && Objects.equals(this.term1, that.term1)
             && Objects.equals(this.term2, that.term2)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -175,7 +185,8 @@ public final class CEqual implements IConstraint, Serializable {
                 term1,
                 term2,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CEqual.java
@@ -122,27 +122,27 @@ public final class CEqual implements IConstraint, Serializable {
         }
     }
 
-    @Override public CEqual apply(ISubstitution.Immutable subst) {
+    @Override public CEqual apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CEqual(
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CEqual unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CEqual unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CEqual apply(IRenaming subst) {
+    @Override public CEqual apply(IRenaming subst, boolean trackOrigin) {
         return new CEqual(
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -143,6 +143,17 @@ public final class CExists implements IConstraint, Serializable {
         });
     }
 
+    @Override public CExists apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CExists unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CExists apply(IRenaming subst) {
+        return apply(subst, false);
+    }
 
     @Override public CExists apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         ISubstitution.Immutable localSubst = subst.removeAll(vars).retainAll(freeVars());

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -26,17 +26,18 @@ public final class CExists implements IConstraint, Serializable {
     private final IConstraint constraint;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CExists origin;
     private final @Nullable ICompleteness.Immutable bodyCriticalEdges;
 
     private volatile Set.Immutable<ITermVar> freeVars;
 
     public CExists(Iterable<ITermVar> vars, IConstraint constraint) {
-        this(vars, constraint, null, null, null);
+        this(vars, constraint, null, null, null, null);
     }
 
     // Do not call this constructor. Call withArguments() or withCause() instead.
     public CExists(Iterable<ITermVar> vars, IConstraint constraint, @Nullable IConstraint cause) {
-        this(vars, constraint, cause, null, null);
+        this(vars, constraint, cause, null, null, null);
     }
 
     // Do not call this constructor. Call withArguments(), withCause(), or withBodyCriticalEdges() instead.
@@ -46,7 +47,7 @@ public final class CExists implements IConstraint, Serializable {
             @Nullable IConstraint cause,
             ICompleteness.Immutable bodyCriticalEdges
     ) {
-        this(vars, constraint, cause, bodyCriticalEdges, null);
+        this(vars, constraint, cause, null, bodyCriticalEdges, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -54,12 +55,14 @@ public final class CExists implements IConstraint, Serializable {
             Iterable<ITermVar> vars,
             IConstraint constraint,
             @Nullable IConstraint cause,
+            @Nullable CExists origin,
             @Nullable ICompleteness.Immutable bodyCriticalEdges,
             @Nullable Set.Immutable<ITermVar> freeVars
     ) {
         this.vars = CapsuleUtil.toSet(vars);
         this.constraint = constraint;
         this.cause = cause;
+        this.origin = origin;
         this.bodyCriticalEdges = bodyCriticalEdges;
         this.freeVars = freeVars;
     }
@@ -78,7 +81,7 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     public CExists withArguments(Iterable<ITermVar> vars, IConstraint constraint) {
-        return new CExists(vars, constraint, cause, bodyCriticalEdges, null);
+        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -86,7 +89,11 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     @Override public CExists withCause(@Nullable IConstraint cause) {
-        return new CExists(vars, constraint, cause, bodyCriticalEdges, freeVars);
+        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, freeVars);
+    }
+
+    @Override public @Nullable CExists origin() {
+        return origin;
     }
 
     @Override public Optional<ICompleteness.Immutable> bodyCriticalEdges() {
@@ -94,7 +101,7 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     @Override public CExists withBodyCriticalEdges(@Nullable ICompleteness.Immutable criticalEdges) {
-        return new CExists(vars, constraint, cause, criticalEdges, freeVars);
+        return new CExists(vars, constraint, cause, origin, criticalEdges, freeVars);
     }
 
 
@@ -166,7 +173,7 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
 
-        return new CExists(vars, constraint, cause, bodyCriticalEdges, freeVars);
+        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, freeVars);
     }
 
     @Override public CExists unsafeApply(ISubstitution.Immutable subst) {
@@ -183,7 +190,7 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
 
-        return new CExists(vars, constraint, cause, bodyCriticalEdges, null);
+        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
     }
 
     @Override public CExists apply(IRenaming subst) {
@@ -197,7 +204,7 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(subst);
         }
 
-        return new CExists(vars, constraint, cause, bodyCriticalEdges, null);
+        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
     }
 
 
@@ -223,7 +230,8 @@ public final class CExists implements IConstraint, Serializable {
         return this.hashCode == that.hashCode
             && Objects.equals(this.vars, that.vars)
             && Objects.equals(this.constraint, that.constraint)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -237,7 +245,8 @@ public final class CExists implements IConstraint, Serializable {
         return Objects.hash(
                 vars,
                 constraint,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -81,6 +81,13 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     public CExists withArguments(Iterable<ITermVar> vars, IConstraint constraint) {
+        if (this.vars == vars &&
+            this.constraint == constraint
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
     }
 
@@ -89,6 +96,11 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     @Override public CExists withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, freeVars);
     }
 
@@ -101,6 +113,11 @@ public final class CExists implements IConstraint, Serializable {
     }
 
     @Override public CExists withBodyCriticalEdges(@Nullable ICompleteness.Immutable criticalEdges) {
+        if (this.bodyCriticalEdges == criticalEdges) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CExists(vars, constraint, cause, origin, criticalEdges, freeVars);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -179,7 +179,7 @@ public final class CExists implements IConstraint, Serializable {
             localSubst = ren.asSubstitution().compose(localSubst);
         }
 
-        constraint = constraint.apply(localSubst);
+        constraint = constraint.apply(localSubst, trackOrigin);
         if (bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
@@ -203,7 +203,7 @@ public final class CExists implements IConstraint, Serializable {
         IConstraint constraint = this.constraint;
         @Nullable ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges;
 
-        constraint = constraint.unsafeApply(localSubst);
+        constraint = constraint.unsafeApply(localSubst, trackOrigin);
         if (bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
@@ -224,7 +224,7 @@ public final class CExists implements IConstraint, Serializable {
         ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges;
 
         vars = CapsuleUtil.toSet(subst.rename(vars));
-        constraint = constraint.apply(subst);
+        constraint = constraint.apply(subst, trackOrigin);
         if (bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(subst);
         }

--- a/statix.solver/src/main/java/mb/statix/constraints/CExists.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CExists.java
@@ -144,7 +144,7 @@ public final class CExists implements IConstraint, Serializable {
     }
 
 
-    @Override public CExists apply(ISubstitution.Immutable subst) {
+    @Override public CExists apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         ISubstitution.Immutable localSubst = subst.removeAll(vars).retainAll(freeVars());
         if (localSubst.isEmpty()) {
             return this;
@@ -173,10 +173,17 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
 
-        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, freeVars);
+        return new CExists(
+                vars,
+                constraint,
+                cause,
+                origin == null && trackOrigin ? this : origin,
+                bodyCriticalEdges,
+                freeVars
+        );
     }
 
-    @Override public CExists unsafeApply(ISubstitution.Immutable subst) {
+    @Override public CExists unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         ISubstitution.Immutable localSubst = subst.removeAll(vars);
         if (localSubst.isEmpty()) {
             return this;
@@ -190,10 +197,17 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
 
-        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
+        return new CExists(
+                vars,
+                constraint,
+                cause,
+                origin == null && trackOrigin ? this : origin,
+                bodyCriticalEdges,
+                null
+        );
     }
 
-    @Override public CExists apply(IRenaming subst) {
+    @Override public CExists apply(IRenaming subst, boolean trackOrigin) {
         Set.Immutable<ITermVar> vars = this.vars;
         IConstraint constraint = this.constraint;
         ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges;
@@ -204,7 +218,14 @@ public final class CExists implements IConstraint, Serializable {
             bodyCriticalEdges = bodyCriticalEdges.apply(subst);
         }
 
-        return new CExists(vars, constraint, cause, origin, bodyCriticalEdges, null);
+        return new CExists(
+                vars,
+                constraint,
+                cause,
+                origin == null && trackOrigin ? this : origin,
+                bodyCriticalEdges,
+                null
+        );
     }
 
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -23,27 +23,30 @@ public final class CFalse implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CFalse origin;
 
     public CFalse() {
-        this(null, null);
+        this(null, null, null);
     }
 
     // This constructor is primarily used to reconstruct this object from a Statix term. Call withMessage() instead.
     public CFalse(@Nullable IMessage message) {
-        this(null, message);
+        this(null, message, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
     private CFalse(
             @Nullable IConstraint cause,
-            @Nullable IMessage message
+            @Nullable IMessage message,
+            @Nullable CFalse origin
     ) {
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
     }
 
     public CFalse withArguments() {
-        return new CFalse(cause, message);
+        return new CFalse(cause, message, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -51,7 +54,7 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse withCause(@Nullable IConstraint cause) {
-        return new CFalse(cause, message);
+        return new CFalse(cause, message, origin);
     }
 
     @Override public Optional<IMessage> message() {
@@ -59,7 +62,11 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse withMessage(@Nullable IMessage message) {
-        return new CFalse(cause, message);
+        return new CFalse(cause, message, origin);
+    }
+
+    @Override public @Nullable CFalse origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -91,7 +98,7 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse apply(ISubstitution.Immutable subst) {
-        return new CFalse(cause, message == null ? null : message.apply(subst));
+        return new CFalse(cause, message == null ? null : message.apply(subst), origin);
     }
 
     @Override public CFalse unsafeApply(ISubstitution.Immutable subst) {
@@ -99,7 +106,7 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse apply(IRenaming subst) {
-        return new CFalse(cause, message == null ? null : message.apply(subst));
+        return new CFalse(cause, message == null ? null : message.apply(subst), origin);
     }
 
     @Override public String toString(@SuppressWarnings("unused") TermFormatter termToString) {
@@ -119,7 +126,8 @@ public final class CFalse implements IConstraint, Serializable {
         // @formatter:off
         return this.hashCode == that.hashCode
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -132,7 +140,8 @@ public final class CFalse implements IConstraint, Serializable {
     private int computeHashCode() {
         return Objects.hash(
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -46,7 +46,8 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     public CFalse withArguments() {
-        return new CFalse(cause, message, origin);
+        // Avoid creating new objects.
+        return this;
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -54,6 +55,11 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CFalse(cause, message, origin);
     }
 
@@ -62,6 +68,11 @@ public final class CFalse implements IConstraint, Serializable {
     }
 
     @Override public CFalse withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CFalse(cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -97,16 +97,24 @@ public final class CFalse implements IConstraint, Serializable {
         }
     }
 
-    @Override public CFalse apply(ISubstitution.Immutable subst) {
-        return new CFalse(cause, message == null ? null : message.apply(subst), origin);
+    @Override public CFalse apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CFalse(
+                cause,
+                message == null ? null : message.apply(subst),
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CFalse unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CFalse unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CFalse apply(IRenaming subst) {
-        return new CFalse(cause, message == null ? null : message.apply(subst), origin);
+    @Override public CFalse apply(IRenaming subst, boolean trackOrigin) {
+        return new CFalse(
+                cause,
+                message == null ? null : message.apply(subst),
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
     @Override public String toString(@SuppressWarnings("unused") TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CFalse.java
@@ -97,6 +97,18 @@ public final class CFalse implements IConstraint, Serializable {
         }
     }
 
+    @Override public CFalse apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CFalse unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CFalse apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CFalse apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CFalse(
                 cause,

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -29,9 +29,10 @@ public final class CInequal implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CInequal origin;
 
     public CInequal(Iterable<ITermVar> universals, ITerm term1, ITerm term2) {
-        this(universals, term1, term2, null, null);
+        this(universals, term1, term2, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
@@ -41,7 +42,7 @@ public final class CInequal implements IConstraint, Serializable {
             ITerm term2,
             @Nullable IMessage message
     ) {
-        this(universals, term1, term2, null, message);
+        this(universals, term1, term2, null, message, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -50,13 +51,15 @@ public final class CInequal implements IConstraint, Serializable {
             ITerm term1,
             ITerm term2,
             @Nullable IConstraint cause,
-            @Nullable IMessage message
+            @Nullable IMessage message,
+            @Nullable CInequal origin
     ) {
         this.universals = CapsuleUtil.toSet(universals);
         this.term1 = term1;
         this.term2 = term2;
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
     }
 
     public Set<ITermVar> universals() {
@@ -72,7 +75,7 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     public CInequal withArguments(Iterable<ITermVar> universals, ITerm term1, ITerm term2) {
-        return new CInequal(universals, term1, term2, cause, message);
+        return new CInequal(universals, term1, term2, cause, message, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -80,7 +83,7 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     @Override public CInequal withCause(@Nullable IConstraint cause) {
-        return new CInequal(universals, term1, term2, cause, message);
+        return new CInequal(universals, term1, term2, cause, message, origin);
     }
 
     @Override public Optional<IMessage> message() {
@@ -88,7 +91,11 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     @Override public CInequal withMessage(@Nullable IMessage message) {
-        return new CInequal(universals, term1, term2, cause, message);
+        return new CInequal(universals, term1, term2, cause, message, origin);
+    }
+
+    @Override public @Nullable CInequal origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -135,7 +142,8 @@ public final class CInequal implements IConstraint, Serializable {
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -152,7 +160,8 @@ public final class CInequal implements IConstraint, Serializable {
                 subst.apply(term1),
                 subst.apply(term2),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -188,7 +197,8 @@ public final class CInequal implements IConstraint, Serializable {
             && Objects.equals(this.term1, that.term1)
             && Objects.equals(this.term2, that.term2)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -204,7 +214,8 @@ public final class CInequal implements IConstraint, Serializable {
                 term1,
                 term2,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -130,7 +130,18 @@ public final class CInequal implements IConstraint, Serializable {
         if (message != null) {
             message.visitVars(onFreeVar);
         }
+    }
 
+    @Override public CInequal apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CInequal unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CInequal apply(IRenaming subst) {
+        return apply(subst, false);
     }
 
     @Override public CInequal apply(ISubstitution.Immutable subst, boolean trackOrigin) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -133,7 +133,7 @@ public final class CInequal implements IConstraint, Serializable {
 
     }
 
-    @Override public CInequal apply(ISubstitution.Immutable subst) {
+    @Override public CInequal apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         final Set.Immutable<ITermVar> us = universals.stream()
                 .flatMap(v -> subst.apply(v).getVars().stream())
                 .collect(CapsuleCollectors.toSet());
@@ -143,15 +143,15 @@ public final class CInequal implements IConstraint, Serializable {
                 subst.apply(term2),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CInequal unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CInequal unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CInequal apply(IRenaming subst) {
+    @Override public CInequal apply(IRenaming subst, boolean trackOrigin) {
         final Set.Immutable<ITermVar> us = universals.stream()
                 .map(subst::rename)
                 .collect(CapsuleCollectors.toSet());
@@ -161,7 +161,7 @@ public final class CInequal implements IConstraint, Serializable {
                 subst.apply(term2),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CInequal.java
@@ -75,6 +75,13 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     public CInequal withArguments(Iterable<ITermVar> universals, ITerm term1, ITerm term2) {
+        if (this.universals == universals &&
+            this.term1 == term1 &&
+            this.term2 == term2
+        ) {
+            // Avoid creating new objects.
+            return this;
+        }
         return new CInequal(universals, term1, term2, cause, message, origin);
     }
 
@@ -83,6 +90,11 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     @Override public CInequal withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CInequal(universals, term1, term2, cause, message, origin);
     }
 
@@ -91,6 +103,11 @@ public final class CInequal implements IConstraint, Serializable {
     }
 
     @Override public CInequal withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CInequal(universals, term1, term2, cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -109,6 +109,18 @@ public final class CNew implements IConstraint, Serializable {
         datumTerm.getVars().stream().forEach(onFreeVar::apply);
     }
 
+    @Override public CNew apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CNew unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CNew apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CNew apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CNew(
                 subst.apply(scopeTerm),

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -56,6 +56,13 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     public CNew withArguments(ITerm scopeTerm, ITerm datumTerm) {
+        if (this.scopeTerm == scopeTerm &&
+            this.datumTerm == datumTerm
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CNew(scopeTerm, datumTerm, cause, origin, ownCriticalEdges);
     }
 
@@ -79,6 +86,11 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     @Override public CNew withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CNew(scopeTerm, datumTerm, cause, origin, ownCriticalEdges);
     }
 
@@ -91,6 +103,11 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     @Override public CNew withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
+        if (this.ownCriticalEdges == criticalEdges) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CNew(scopeTerm, datumTerm, cause, origin, criticalEdges);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -26,9 +26,10 @@ public final class CNew implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable ICompleteness.Immutable ownCriticalEdges;
+    private final @Nullable CNew origin;
 
     public CNew(ITerm scopeTerm, ITerm datumTerm) {
-        this(scopeTerm, datumTerm, null, null);
+        this(scopeTerm, datumTerm, null, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -36,11 +37,13 @@ public final class CNew implements IConstraint, Serializable {
             ITerm scopeTerm,
             ITerm datumTerm,
             @Nullable IConstraint cause,
+            @Nullable CNew origin,
             @Nullable ICompleteness.Immutable ownCriticalEdges
     ) {
         this.scopeTerm = scopeTerm;
         this.datumTerm = datumTerm;
         this.cause = cause;
+        this.origin = origin;
         this.ownCriticalEdges = ownCriticalEdges;
     }
 
@@ -53,7 +56,7 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     public CNew withArguments(ITerm scopeTerm, ITerm datumTerm) {
-        return new CNew(scopeTerm, datumTerm, cause, ownCriticalEdges);
+        return new CNew(scopeTerm, datumTerm, cause, origin, ownCriticalEdges);
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -76,7 +79,11 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     @Override public CNew withCause(@Nullable IConstraint cause) {
-        return new CNew(scopeTerm, datumTerm, cause, ownCriticalEdges);
+        return new CNew(scopeTerm, datumTerm, cause, origin, ownCriticalEdges);
+    }
+
+    @Override public @Nullable CNew origin() {
+        return origin;
     }
 
     @Override public Optional<ICompleteness.Immutable> ownCriticalEdges() {
@@ -84,7 +91,7 @@ public final class CNew implements IConstraint, Serializable {
     }
 
     @Override public CNew withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
-        return new CNew(scopeTerm, datumTerm, cause, criticalEdges);
+        return new CNew(scopeTerm, datumTerm, cause, origin, criticalEdges);
     }
 
     @Override public Set.Immutable<ITermVar> freeVars() {
@@ -107,6 +114,7 @@ public final class CNew implements IConstraint, Serializable {
                 subst.apply(scopeTerm),
                 subst.apply(datumTerm),
                 cause,
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -120,6 +128,7 @@ public final class CNew implements IConstraint, Serializable {
                 subst.apply(scopeTerm),
                 subst.apply(datumTerm),
                 cause,
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -147,7 +156,8 @@ public final class CNew implements IConstraint, Serializable {
         return this.hashCode == that.hashCode
             && Objects.equals(this.scopeTerm, that.scopeTerm)
             && Objects.equals(this.datumTerm, that.datumTerm)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -161,7 +171,8 @@ public final class CNew implements IConstraint, Serializable {
         return Objects.hash(
                 scopeTerm,
                 datumTerm,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CNew.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CNew.java
@@ -109,26 +109,26 @@ public final class CNew implements IConstraint, Serializable {
         datumTerm.getVars().stream().forEach(onFreeVar::apply);
     }
 
-    @Override public CNew apply(ISubstitution.Immutable subst) {
+    @Override public CNew apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CNew(
                 subst.apply(scopeTerm),
                 subst.apply(datumTerm),
                 cause,
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
 
-    @Override public CNew unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CNew unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CNew apply(IRenaming subst) {
+    @Override public CNew apply(IRenaming subst, boolean trackOrigin) {
         return new CNew(
                 subst.apply(scopeTerm),
                 subst.apply(datumTerm),
                 cause,
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -54,7 +54,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
         this.origin = origin;
     }
 
-    public CResolveQuery withArguments(
+    @Override public CResolveQuery withArguments(
             QueryFilter filter,
             QueryMin min,
             QueryProject project,

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -119,8 +119,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
 
     @Override public CResolveQuery apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CResolveQuery(
-                filter.apply(subst),
-                min.apply(subst),
+                filter.apply(subst, trackOrigin),
+                min.apply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
@@ -132,8 +132,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
 
     @Override public CResolveQuery unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CResolveQuery(
-                filter.unsafeApply(subst),
-                min.unsafeApply(subst),
+                filter.unsafeApply(subst, trackOrigin),
+                min.unsafeApply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
@@ -145,8 +145,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
 
     @Override public CResolveQuery apply(IRenaming subst, boolean trackOrigin) {
         return new CResolveQuery(
-                filter.apply(subst),
-                min.apply(subst),
+                filter.apply(subst, trackOrigin),
+                min.apply(subst, trackOrigin),
                 project,
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -85,7 +85,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
         return origin;
     }
 
-    @Override public CResolveQuery apply(ISubstitution.Immutable subst) {
+    @Override public CResolveQuery apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CResolveQuery(
                 filter.apply(subst),
                 min.apply(subst),
@@ -94,11 +94,11 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CResolveQuery unsafeApply(ISubstitution.Immutable subst) {
+    @Override public CResolveQuery unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CResolveQuery(
                 filter.unsafeApply(subst),
                 min.unsafeApply(subst),
@@ -107,11 +107,11 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CResolveQuery apply(IRenaming subst) {
+    @Override public CResolveQuery apply(IRenaming subst, boolean trackOrigin) {
         return new CResolveQuery(
                 filter.apply(subst),
                 min.apply(subst),
@@ -120,7 +120,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(resultTerm),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -61,6 +61,16 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
             ITerm scopeTerm,
             ITerm resultTerm
     ) {
+        if (this.filter == filter &&
+            this.min == min &&
+            this.project == project &&
+            this.scopeTerm == scopeTerm &&
+            this.resultTerm == resultTerm
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
     }
 
@@ -74,10 +84,20 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
     }
 
     @Override public CResolveQuery withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
     }
 
     @Override public CResolveQuery withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -85,6 +85,18 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
         return origin;
     }
 
+    @Override public CResolveQuery apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CResolveQuery unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CResolveQuery apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CResolveQuery apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CResolveQuery(
                 filter.apply(subst),

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -54,7 +54,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
         this.origin = origin;
     }
 
-    @Override public CResolveQuery withArguments(
+    public CResolveQuery withArguments(
             QueryFilter filter,
             QueryMin min,
             QueryProject project,

--- a/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CResolveQuery.java
@@ -20,8 +20,10 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private final @Nullable CResolveQuery origin;
+
     public CResolveQuery(QueryFilter filter, QueryMin min, QueryProject project, ITerm scopeTerm, ITerm resultTerm) {
-        this(filter, min, project, scopeTerm, resultTerm, null, null);
+        this(filter, min, project, scopeTerm, resultTerm, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
@@ -33,7 +35,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
             ITerm resultTerm,
             @Nullable IMessage message
     ) {
-        this(filter, min, project, scopeTerm, resultTerm, null, message);
+        this(filter, min, project, scopeTerm, resultTerm, null, message, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -44,9 +46,12 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
             ITerm scopeTerm,
             ITerm resultTerm,
             @Nullable IConstraint cause,
-            @Nullable IMessage message
+            @Nullable IMessage message,
+            @Nullable CResolveQuery origin
     ) {
         super(filter, min, project, scopeTerm, resultTerm, cause, message);
+
+        this.origin = origin;
     }
 
     public CResolveQuery withArguments(
@@ -56,7 +61,7 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
             ITerm scopeTerm,
             ITerm resultTerm
     ) {
-        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message);
+        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -69,11 +74,15 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
     }
 
     @Override public CResolveQuery withCause(@Nullable IConstraint cause) {
-        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message);
+        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
     }
 
     @Override public CResolveQuery withMessage(@Nullable IMessage message) {
-        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message);
+        return new CResolveQuery(filter, min, project, scopeTerm, resultTerm, cause, message, origin);
+    }
+
+    @Override public @Nullable CResolveQuery origin() {
+        return origin;
     }
 
     @Override public CResolveQuery apply(ISubstitution.Immutable subst) {
@@ -84,7 +93,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -96,7 +106,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -108,7 +119,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 subst.apply(scopeTerm),
                 subst.apply(resultTerm),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -141,7 +153,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
             && Objects.equals(this.scopeTerm, that.scopeTerm)
             && Objects.equals(this.resultTerm, that.resultTerm)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -159,7 +172,8 @@ public final class CResolveQuery extends AResolveQuery implements Serializable {
                 scopeTerm,
                 resultTerm,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -116,6 +116,18 @@ public final class CTellEdge implements IConstraint, Serializable {
         targetTerm.getVars().forEach(onFreeVar::apply);
     }
 
+    @Override public CTellEdge apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CTellEdge unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CTellEdge apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CTellEdge apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTellEdge(
                 subst.apply(sourceTerm),

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -26,10 +26,11 @@ public final class CTellEdge implements IConstraint, Serializable {
     private final ITerm targetTerm;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CTellEdge origin;
     private final @Nullable ICompleteness.Immutable ownCriticalEdges;
 
     public CTellEdge(ITerm sourceTerm, ITerm label, ITerm targetTerm) {
-        this(sourceTerm, label, targetTerm, null, null);
+        this(sourceTerm, label, targetTerm, null, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -38,12 +39,14 @@ public final class CTellEdge implements IConstraint, Serializable {
             ITerm label,
             ITerm targetTerm,
             @Nullable IConstraint cause,
+            @Nullable CTellEdge origin,
             @Nullable ICompleteness.Immutable ownCriticalEdges
     ) {
         this.sourceTerm = sourceTerm;
         this.label = label;
         this.targetTerm = targetTerm;
         this.cause = cause;
+        this.origin = origin;
         this.ownCriticalEdges = ownCriticalEdges;
     }
 
@@ -60,7 +63,7 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     public CTellEdge withArguments(ITerm sourceTerm, ITerm label, ITerm targetTerm) {
-        return new CTellEdge(sourceTerm, label, targetTerm, cause, ownCriticalEdges);
+        return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, ownCriticalEdges);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -68,7 +71,11 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     @Override public CTellEdge withCause(@Nullable IConstraint cause) {
-        return new CTellEdge(sourceTerm, label, targetTerm, cause, ownCriticalEdges);
+        return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, ownCriticalEdges);
+    }
+
+    @Override public @Nullable CTellEdge origin() {
+        return origin;
     }
 
     @Override public Optional<ICompleteness.Immutable> ownCriticalEdges() {
@@ -76,7 +83,7 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     @Override public CTellEdge withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
-        return new CTellEdge(sourceTerm, label, targetTerm, cause, criticalEdges);
+        return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, criticalEdges);
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -115,6 +122,7 @@ public final class CTellEdge implements IConstraint, Serializable {
                 label,
                 subst.apply(targetTerm),
                 cause,
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -129,6 +137,7 @@ public final class CTellEdge implements IConstraint, Serializable {
                 label,
                 subst.apply(targetTerm),
                 cause,
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -158,7 +167,8 @@ public final class CTellEdge implements IConstraint, Serializable {
             && Objects.equals(this.sourceTerm, that.sourceTerm)
             && Objects.equals(this.label, that.label)
             && Objects.equals(this.targetTerm, that.targetTerm)
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -173,7 +183,8 @@ public final class CTellEdge implements IConstraint, Serializable {
                 sourceTerm,
                 label,
                 targetTerm,
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -116,28 +116,28 @@ public final class CTellEdge implements IConstraint, Serializable {
         targetTerm.getVars().forEach(onFreeVar::apply);
     }
 
-    @Override public CTellEdge apply(ISubstitution.Immutable subst) {
+    @Override public CTellEdge apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTellEdge(
                 subst.apply(sourceTerm),
                 label,
                 subst.apply(targetTerm),
                 cause,
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
 
-    @Override public CTellEdge unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CTellEdge unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CTellEdge apply(IRenaming subst) {
+    @Override public CTellEdge apply(IRenaming subst, boolean trackOrigin) {
         return new CTellEdge(
                 subst.apply(sourceTerm),
                 label,
                 subst.apply(targetTerm),
                 cause,
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }

--- a/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTellEdge.java
@@ -63,6 +63,14 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     public CTellEdge withArguments(ITerm sourceTerm, ITerm label, ITerm targetTerm) {
+        if (this.sourceTerm == sourceTerm &&
+            this.label == label &&
+            this.targetTerm == targetTerm
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, ownCriticalEdges);
     }
 
@@ -71,6 +79,11 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     @Override public CTellEdge withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, ownCriticalEdges);
     }
 
@@ -83,6 +96,11 @@ public final class CTellEdge implements IConstraint, Serializable {
     }
 
     @Override public CTellEdge withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
+        if (this.ownCriticalEdges == criticalEdges) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTellEdge(sourceTerm, label, targetTerm, cause, origin, criticalEdges);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -34,7 +34,8 @@ public final class CTrue implements IConstraint, Serializable {
     }
 
     public CTrue withArguments() {
-        return new CTrue(cause, origin);
+        // Avoid creating new objects.
+        return this;
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -42,6 +43,11 @@ public final class CTrue implements IConstraint, Serializable {
     }
 
     @Override public CTrue withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTrue(cause, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -21,18 +21,20 @@ public final class CTrue implements IConstraint, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final @Nullable IConstraint cause;
+    private final @Nullable CTrue origin;
 
     public CTrue() {
-        this(null);
+        this(null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
-    private CTrue(@Nullable IConstraint cause) {
+    private CTrue(@Nullable IConstraint cause, @Nullable CTrue origin) {
         this.cause = cause;
+        this.origin = origin;
     }
 
     public CTrue withArguments() {
-        return new CTrue(cause);
+        return new CTrue(cause, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -40,7 +42,11 @@ public final class CTrue implements IConstraint, Serializable {
     }
 
     @Override public CTrue withCause(@Nullable IConstraint cause) {
-        return new CTrue(cause);
+        return new CTrue(cause, origin);
+    }
+
+    @Override public @Nullable CTrue origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -96,7 +102,8 @@ public final class CTrue implements IConstraint, Serializable {
         final CTrue that = (CTrue)o;
         // @formatter:off
         return this.hashCode == that.hashCode
-            && Objects.equals(this.cause, that.cause);
+            && Objects.equals(this.cause, that.cause)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -108,7 +115,8 @@ public final class CTrue implements IConstraint, Serializable {
 
     private int computeHashCode() {
         return Objects.hash(
-                cause
+                cause,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -74,6 +74,18 @@ public final class CTrue implements IConstraint, Serializable {
     private void doVisitFreeVars(@SuppressWarnings("unused") Action1<ITermVar> onFreeVar) {
     }
 
+    @Override public CTrue apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CTrue unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CTrue apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CTrue apply(@SuppressWarnings("unused") ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTrue(
                 cause,

--- a/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTrue.java
@@ -74,16 +74,22 @@ public final class CTrue implements IConstraint, Serializable {
     private void doVisitFreeVars(@SuppressWarnings("unused") Action1<ITermVar> onFreeVar) {
     }
 
-    @Override public CTrue apply(@SuppressWarnings("unused") ISubstitution.Immutable subst) {
-        return this;
+    @Override public CTrue apply(@SuppressWarnings("unused") ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new CTrue(
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
-    @Override public CTrue unsafeApply(@SuppressWarnings("unused") ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CTrue unsafeApply(@SuppressWarnings("unused") ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CTrue apply(@SuppressWarnings("unused") IRenaming subst) {
-        return this;
+    @Override public CTrue apply(@SuppressWarnings("unused") IRenaming subst, boolean trackOrigin) {
+        return new CTrue(
+                cause,
+                origin == null && trackOrigin ? this : origin
+        );
     }
 
     @Override public String toString(@SuppressWarnings("unused") TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -49,6 +49,11 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     public CTry withArguments(IConstraint constraint) {
+        if (this.constraint == constraint) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTry(constraint, cause, message, origin);
     }
 
@@ -57,6 +62,11 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     @Override public CTry withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTry(constraint, cause, message, origin);
     }
 
@@ -65,6 +75,11 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     @Override public CTry withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CTry(constraint, cause, message, origin);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -101,30 +101,30 @@ public final class CTry implements IConstraint, Serializable {
         }
     }
 
-    @Override public CTry apply(ISubstitution.Immutable subst) {
+    @Override public CTry apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTry(
                 constraint.apply(subst),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CTry unsafeApply(ISubstitution.Immutable subst) {
+    @Override public CTry unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTry(
                 constraint.unsafeApply(subst),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 
-    @Override public CTry apply(IRenaming subst) {
+    @Override public CTry apply(IRenaming subst, boolean trackOrigin) {
         return new CTry(
                 constraint.apply(subst),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin
+                origin == null && trackOrigin ? this : origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -25,21 +25,23 @@ public final class CTry implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CTry origin;
 
     public CTry(IConstraint constraint) {
-        this(constraint, null, null);
+        this(constraint, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
     public CTry(IConstraint constraint, @Nullable IMessage message) {
-        this(constraint, null, message);
+        this(constraint, null, message, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
-    private CTry(IConstraint constraint, @Nullable IConstraint cause, @Nullable IMessage message) {
+    private CTry(IConstraint constraint, @Nullable IConstraint cause, @Nullable IMessage message, @Nullable CTry origin) {
         this.constraint = constraint;
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
     }
 
     public IConstraint constraint() {
@@ -47,7 +49,7 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     public CTry withArguments(IConstraint constraint) {
-        return new CTry(constraint, cause, message);
+        return new CTry(constraint, cause, message, origin);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -55,7 +57,7 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     @Override public CTry withCause(@Nullable IConstraint cause) {
-        return new CTry(constraint, cause, message);
+        return new CTry(constraint, cause, message, origin);
     }
 
     @Override public Optional<IMessage> message() {
@@ -63,7 +65,11 @@ public final class CTry implements IConstraint, Serializable {
     }
 
     @Override public CTry withMessage(@Nullable IMessage message) {
-        return new CTry(constraint, cause, message);
+        return new CTry(constraint, cause, message, origin);
+    }
+
+    @Override public @Nullable CTry origin() {
+        return origin;
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -99,7 +105,8 @@ public final class CTry implements IConstraint, Serializable {
         return new CTry(
                 constraint.apply(subst),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -107,7 +114,8 @@ public final class CTry implements IConstraint, Serializable {
         return new CTry(
                 constraint.unsafeApply(subst),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -115,7 +123,8 @@ public final class CTry implements IConstraint, Serializable {
         return new CTry(
                 constraint.apply(subst),
                 cause,
-                message == null ? null : message.apply(subst)
+                message == null ? null : message.apply(subst),
+                origin
         );
     }
 
@@ -141,7 +150,8 @@ public final class CTry implements IConstraint, Serializable {
         return this.hashCode == that.hashCode
             && Objects.equals(this.constraint, that.constraint)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -155,7 +165,8 @@ public final class CTry implements IConstraint, Serializable {
         return Objects.hash(
                 constraint,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -101,6 +101,18 @@ public final class CTry implements IConstraint, Serializable {
         }
     }
 
+    @Override public CTry apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CTry unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CTry apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CTry apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTry(
                 constraint.apply(subst),

--- a/statix.solver/src/main/java/mb/statix/constraints/CTry.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CTry.java
@@ -115,7 +115,7 @@ public final class CTry implements IConstraint, Serializable {
 
     @Override public CTry apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTry(
-                constraint.apply(subst),
+                constraint.apply(subst, trackOrigin),
                 cause,
                 message == null ? null : message.apply(subst),
                 origin == null && trackOrigin ? this : origin
@@ -124,7 +124,7 @@ public final class CTry implements IConstraint, Serializable {
 
     @Override public CTry unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CTry(
-                constraint.unsafeApply(subst),
+                constraint.unsafeApply(subst, trackOrigin),
                 cause,
                 message == null ? null : message.apply(subst),
                 origin == null && trackOrigin ? this : origin
@@ -133,7 +133,7 @@ public final class CTry implements IConstraint, Serializable {
 
     @Override public CTry apply(IRenaming subst, boolean trackOrigin) {
         return new CTry(
-                constraint.apply(subst),
+                constraint.apply(subst, trackOrigin),
                 cause,
                 message == null ? null : message.apply(subst),
                 origin == null && trackOrigin ? this : origin

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -67,6 +67,14 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     public CUser withArguments(String name, Iterable<? extends ITerm> args) {
+        //noinspection StringEquality
+        if (this.name == name &&
+            this.args == args
+        ) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CUser(name, args, cause, message, origin, ownCriticalEdges);
     }
 
@@ -75,6 +83,11 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withCause(@Nullable IConstraint cause) {
+        if (this.cause == cause) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CUser(name, args, cause, message, origin, ownCriticalEdges);
     }
 
@@ -83,6 +96,11 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withMessage(@Nullable IMessage message) {
+        if (this.message == message) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CUser(name, args, cause, message, origin, ownCriticalEdges);
     }
 
@@ -95,6 +113,11 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
+        if (this.ownCriticalEdges == criticalEdges) {
+            // Avoid creating new objects if the arguments are the exact same objects.
+            // NOTE: Using `==` (instead of `Objects.equals()`) is cheap and already covers 99% of cases.
+            return this;
+        }
         return new CUser(name, args, cause, message, origin, criticalEdges);
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -131,6 +131,18 @@ public final class CUser implements IConstraint, Serializable {
         }
     }
 
+    @Override public CUser apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
+
+    @Override public CUser unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
+
+    @Override public CUser apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
     @Override public CUser apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CUser(
                 name,

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -131,28 +131,28 @@ public final class CUser implements IConstraint, Serializable {
         }
     }
 
-    @Override public CUser apply(ISubstitution.Immutable subst) {
+    @Override public CUser apply(ISubstitution.Immutable subst, boolean trackOrigin) {
         return new CUser(
                 name,
                 subst.apply(args),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
 
-    @Override public CUser unsafeApply(ISubstitution.Immutable subst) {
-        return apply(subst);
+    @Override public CUser unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return apply(subst, trackOrigin);
     }
 
-    @Override public CUser apply(IRenaming subst) {
+    @Override public CUser apply(IRenaming subst, boolean trackOrigin) {
         return new CUser(
                 name,
                 subst.apply(args),
                 cause,
                 message == null ? null : message.apply(subst),
-                origin,
+                origin == null && trackOrigin ? this : origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }

--- a/statix.solver/src/main/java/mb/statix/constraints/CUser.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/CUser.java
@@ -29,15 +29,16 @@ public final class CUser implements IConstraint, Serializable {
 
     private final @Nullable IConstraint cause;
     private final @Nullable IMessage message;
+    private final @Nullable CUser origin;
     private final @Nullable ICompleteness.Immutable ownCriticalEdges;
 
     public CUser(String name, Iterable<? extends ITerm> args) {
-        this(name, args, null, null, null);
+        this(name, args, null, null, null, null);
     }
 
     // Do not call this constructor. This is only used to reconstruct this object from a Statix term. Call withArguments() or withMessage() instead.
     public CUser(String name, Iterable<? extends ITerm> args, @Nullable IMessage message) {
-        this(name, args, null, message, null);
+        this(name, args, null, message, null, null);
     }
 
     // Private constructor, so we can add more fields in the future. Externally call the appropriate with*() functions instead.
@@ -46,12 +47,14 @@ public final class CUser implements IConstraint, Serializable {
             Iterable<? extends ITerm> args,
             @Nullable IConstraint cause,
             @Nullable IMessage message,
+            @Nullable CUser origin,
             @Nullable ICompleteness.Immutable ownCriticalEdges
     ) {
         this.name = name;
         this.args = ImList.Immutable.copyOf(args);
         this.cause = cause;
         this.message = message;
+        this.origin = origin;
         this.ownCriticalEdges = ownCriticalEdges;
     }
 
@@ -64,7 +67,7 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     public CUser withArguments(String name, Iterable<? extends ITerm> args) {
-        return new CUser(name, args, cause, message, ownCriticalEdges);
+        return new CUser(name, args, cause, message, origin, ownCriticalEdges);
     }
 
     @Override public Optional<IConstraint> cause() {
@@ -72,7 +75,7 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withCause(@Nullable IConstraint cause) {
-        return new CUser(name, args, cause, message, ownCriticalEdges);
+        return new CUser(name, args, cause, message, origin, ownCriticalEdges);
     }
 
     @Override public Optional<IMessage> message() {
@@ -80,7 +83,11 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withMessage(@Nullable IMessage message) {
-        return new CUser(name, args, cause, message, ownCriticalEdges);
+        return new CUser(name, args, cause, message, origin, ownCriticalEdges);
+    }
+
+    @Override public @Nullable CUser origin() {
+        return origin;
     }
 
     @Override public Optional<ICompleteness.Immutable> ownCriticalEdges() {
@@ -88,7 +95,7 @@ public final class CUser implements IConstraint, Serializable {
     }
 
     @Override public CUser withOwnCriticalEdges(ICompleteness.Immutable criticalEdges) {
-        return new CUser(name, args, cause, message, criticalEdges);
+        return new CUser(name, args, cause, message, origin, criticalEdges);
     }
 
     @Override public <R> R match(Cases<R> cases) {
@@ -130,6 +137,7 @@ public final class CUser implements IConstraint, Serializable {
                 subst.apply(args),
                 cause,
                 message == null ? null : message.apply(subst),
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -144,6 +152,7 @@ public final class CUser implements IConstraint, Serializable {
                 subst.apply(args),
                 cause,
                 message == null ? null : message.apply(subst),
+                origin,
                 ownCriticalEdges == null ? null : ownCriticalEdges.apply(subst)
         );
     }
@@ -172,7 +181,8 @@ public final class CUser implements IConstraint, Serializable {
             && Objects.equals(this.name, that.name)
             && Objects.equals(this.args, that.args)
             && Objects.equals(this.cause, that.cause)
-            && Objects.equals(this.message, that.message);
+            && Objects.equals(this.message, that.message)
+            && Objects.equals(this.origin, that.origin);
         // @formatter:on
     }
 
@@ -187,7 +197,8 @@ public final class CUser implements IConstraint, Serializable {
                 name,
                 args,
                 cause,
-                message
+                message,
+                origin
         );
     }
 

--- a/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
@@ -1,5 +1,6 @@
 package mb.statix.constraints;
 
+import mb.scopegraph.resolution.StateMachine;
 import org.metaborg.util.functions.Function1;
 
 import mb.nabl2.terms.ITerm;
@@ -35,6 +36,8 @@ public interface IResolveQuery extends IConstraint {
     @Override default <R, E extends Throwable> R matchOrThrow(IConstraint.CheckedCases<R, E> cases) throws E {
         return cases.caseResolveQuery(this);
     }
+
+    IResolveQuery withArguments(QueryFilter filter, QueryMin min, QueryProject project, ITerm scopeTerm, ITerm resultTerm);
 
     interface Cases<R> extends Function1<IResolveQuery, R> {
 

--- a/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
+++ b/statix.solver/src/main/java/mb/statix/constraints/IResolveQuery.java
@@ -1,6 +1,5 @@
 package mb.statix.constraints;
 
-import mb.scopegraph.resolution.StateMachine;
 import org.metaborg.util.functions.Function1;
 
 import mb.nabl2.terms.ITerm;
@@ -36,8 +35,6 @@ public interface IResolveQuery extends IConstraint {
     @Override default <R, E extends Throwable> R matchOrThrow(IConstraint.CheckedCases<R, E> cases) throws E {
         return cases.caseResolveQuery(this);
     }
-
-    IResolveQuery withArguments(QueryFilter filter, QueryMin min, QueryProject project, ITerm scopeTerm, ITerm resultTerm);
 
     interface Cases<R> extends Function1<IResolveQuery, R> {
 

--- a/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
@@ -86,24 +86,24 @@ public interface IConstraint {
 
     /**
      * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
      */
-    default IConstraint apply(ISubstitution.Immutable subst) {
-        return apply(subst, false);
-    }
+    IConstraint apply(ISubstitution.Immutable subst);
 
     /**
      * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
      */
-    default IConstraint unsafeApply(ISubstitution.Immutable subst) {
-        return unsafeApply(subst, false);
-    }
+    IConstraint unsafeApply(ISubstitution.Immutable subst);
 
     /**
      * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
      */
-    default IConstraint apply(IRenaming subst) {
-        return apply(subst, false);
-    }
+    IConstraint apply(IRenaming subst);
 
     /**
      * Apply capture avoiding substitution.

--- a/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
@@ -29,6 +29,8 @@ import mb.statix.constraints.messages.IMessage;
 import mb.statix.solver.completeness.Completeness;
 import mb.statix.solver.completeness.ICompleteness;
 
+import javax.annotation.Nullable;
+
 public interface IConstraint {
 
     Optional<IConstraint> cause();
@@ -38,6 +40,13 @@ public interface IConstraint {
     default Optional<IMessage> message() {
         return Optional.empty();
     }
+
+    /**
+     * The syntactic constraint from which this instance was derived.
+     *
+     * @return a constraint of the same type; or {@code null} if this information was not (yet) recorded
+     */
+    @Nullable IConstraint origin();
 
     default IConstraint withMessage(@SuppressWarnings("unused") IMessage msg) {
         throw new UnsupportedOperationException("Constraint does not support message.");

--- a/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
+++ b/statix.solver/src/main/java/mb/statix/solver/IConstraint.java
@@ -87,17 +87,50 @@ public interface IConstraint {
     /**
      * Apply capture avoiding substitution.
      */
-    IConstraint apply(ISubstitution.Immutable subst);
+    default IConstraint apply(ISubstitution.Immutable subst) {
+        return apply(subst, false);
+    }
 
     /**
      * Apply unguarded substitution, which may result in capture.
      */
-    IConstraint unsafeApply(ISubstitution.Immutable subst);
+    default IConstraint unsafeApply(ISubstitution.Immutable subst) {
+        return unsafeApply(subst, false);
+    }
 
     /**
      * Apply variable renaming.
      */
-    IConstraint apply(IRenaming subst);
+    default IConstraint apply(IRenaming subst) {
+        return apply(subst, false);
+    }
+
+    /**
+     * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to use the current constraint as the syntactic {@link #origin()}
+     *                    of the resulting constraint, if not already tracked
+     */
+    IConstraint apply(ISubstitution.Immutable subst, boolean trackOrigin);
+
+    /**
+     * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to use the current constraint as the syntactic {@link #origin()}
+     *                    of the resulting constraint, if not already tracked
+     */
+    IConstraint unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin);
+
+    /**
+     * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to use the current constraint as the syntactic {@link #origin()}
+     *                    of the resulting constraint, if not already tracked
+     */
+    IConstraint apply(IRenaming subst, boolean trackOrigin);
 
     String toString(TermFormatter termToString);
 

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -703,7 +703,7 @@ class GreedySolver {
                 final ImList.Immutable<Rule> rules = spec.rules().getRules(name);
                 // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
                 final Tuple3<Rule, ApplyResult, Boolean> result;
-                if((result = RuleUtil.applyOrderedOne(state.unifier(), rules, args, c, ApplyMode.RELAXED, Safety.UNSAFE)
+                if((result = RuleUtil.applyOrderedOne(state.unifier(), rules, args, c, ApplyMode.RELAXED, Safety.UNSAFE, true)
                         .orElse(null)) == null) {
                     debug.debug("No rule applies");
                     return fail(c);

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/GreedySolver.java
@@ -430,7 +430,7 @@ class GreedySolver {
                 final Renaming existentials = _existentials.build();
 
                 final ISubstitution.Immutable subst = existentials.asSubstitution();
-                final IConstraint newConstraint = c.constraint().apply(subst).withCause(c.cause().orElse(null));
+                final IConstraint newConstraint = c.constraint().apply(subst, true).withCause(c.cause().orElse(null));
                 if(INCREMENTAL_CRITICAL_EDGES && !c.bodyCriticalEdges().isPresent()) {
                     throw new IllegalArgumentException(
                             "Solver only accepts constraints with pre-computed critical edges.");

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataLeq.java
@@ -40,10 +40,17 @@ class ConstraintDataLeq implements DataLeq<ITerm> {
 
     @Override public boolean leq(ITerm datum1, ITerm datum2) throws ResolutionException, InterruptedException {
         try {
-            final ApplyResult applyResult;
             // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-            if((applyResult = RuleUtil.apply(state.unifier(), constraint, ImList.Immutable.of(datum1, datum2), null,
-                    ApplyMode.STRICT, Safety.UNSAFE).orElse(null)) == null) {
+            final ApplyResult applyResult = RuleUtil.apply(
+                    state.unifier(),
+                    constraint,
+                    ImList.Immutable.of(datum1, datum2),
+                    null,
+                    ApplyMode.STRICT,
+                    Safety.UNSAFE,
+                    true
+            ).orElse(null);
+            if(applyResult == null) {
                 return false;
             }
 

--- a/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
+++ b/statix.solver/src/main/java/mb/statix/solver/persistent/query/ConstraintDataWF.java
@@ -40,18 +40,24 @@ class ConstraintDataWF implements DataWF<ITerm> {
 
     @Override public boolean wf(ITerm datum) throws ResolutionException, InterruptedException {
         try {
-            final ApplyResult applyResult;
             // UNSAFE : we assume the resource of spec variables is empty and of state variables non-empty
-            if((applyResult = RuleUtil
-                    .apply(state.unifier(), constraint, ImList.Immutable.of(datum), null, ApplyMode.STRICT, Safety.UNSAFE)
-                    .orElse(null)) == null) {
+            final ApplyResult applyResult = RuleUtil.apply(
+                    state.unifier(),
+                    constraint,
+                    ImList.Immutable.of(datum),
+                    null,
+                    ApplyMode.STRICT,
+                    Safety.UNSAFE,
+                    true
+            ).orElse(null);
+            if (applyResult == null) {
                 return false;
             }
 
             return Solver.entails(spec, state, Constraints.disjoin(applyResult.body()), Collections.emptyMap(),
                     applyResult.criticalEdges(), isComplete, new NullDebugContext(),
                     new NullProgress().subProgress(1), new NullCancel());
-        } catch(Delay d) {
+        } catch (Delay d) {
             throw new ResolutionDelayException("Data well-formedness delayed.", d);
         }
     }

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
@@ -42,16 +42,61 @@ public class QueryFilter implements Serializable {
         return RuleUtil.vars(dataWf);
     }
 
+    /**
+     * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryFilter apply(ISubstitution.Immutable subst) {
-        return new QueryFilter(pathWf, dataWf.apply(subst));
+        return apply(subst, false);
     }
 
+    /**
+     * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryFilter unsafeApply(ISubstitution.Immutable subst) {
-        return new QueryFilter(pathWf, dataWf.unsafeApply(subst));
+        return unsafeApply(subst, false);
     }
 
+    /**
+     * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryFilter apply(IRenaming subst) {
-        return new QueryFilter(pathWf, dataWf.apply(subst));
+        return apply(subst, false);
+    }
+
+    /**
+     * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryFilter apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigin));
+    }
+
+    /**
+     * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryFilter unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new QueryFilter(pathWf, dataWf.unsafeApply(subst, trackOrigin));
+    }
+
+    /**
+     * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryFilter apply(IRenaming subst, boolean trackOrigin) {
+        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigin));
     }
 
     public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryFilter.java
@@ -73,30 +73,30 @@ public class QueryFilter implements Serializable {
      * Apply capture avoiding substitution.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryFilter apply(ISubstitution.Immutable subst, boolean trackOrigin) {
-        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigin));
+    public QueryFilter apply(ISubstitution.Immutable subst, boolean trackOrigins) {
+        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigins));
     }
 
     /**
      * Apply unguarded substitution, which may result in capture.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryFilter unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
-        return new QueryFilter(pathWf, dataWf.unsafeApply(subst, trackOrigin));
+    public QueryFilter unsafeApply(ISubstitution.Immutable subst, boolean trackOrigins) {
+        return new QueryFilter(pathWf, dataWf.unsafeApply(subst, trackOrigins));
     }
 
     /**
      * Apply variable renaming.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryFilter apply(IRenaming subst, boolean trackOrigin) {
-        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigin));
+    public QueryFilter apply(IRenaming subst, boolean trackOrigins) {
+        return new QueryFilter(pathWf, dataWf.apply(subst, trackOrigins));
     }
 
     public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
@@ -37,16 +37,61 @@ public class QueryMin implements Serializable {
         return RuleUtil.vars(dataOrd);
     }
 
+    /**
+     * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryMin apply(ISubstitution.Immutable subst) {
-        return new QueryMin(labelOrd, dataOrd.apply(subst));
+        return apply(subst, false);
     }
 
+    /**
+     * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryMin unsafeApply(ISubstitution.Immutable subst) {
-        return new QueryMin(labelOrd, dataOrd.unsafeApply(subst));
+        return unsafeApply(subst, false);
     }
 
+    /**
+     * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
+     */
     public QueryMin apply(IRenaming subst) {
-        return new QueryMin(labelOrd, dataOrd.apply(subst));
+        return apply(subst, false);
+    }
+
+    /**
+     * Apply capture avoiding substitution.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryMin apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigin));
+    }
+
+    /**
+     * Apply unguarded substitution, which may result in capture.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryMin unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+        return new QueryMin(labelOrd, dataOrd.unsafeApply(subst, trackOrigin));
+    }
+
+    /**
+     * Apply variable renaming.
+     *
+     * @param subst the substitution to apply
+     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     */
+    public QueryMin apply(IRenaming subst, boolean trackOrigin) {
+        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigin));
     }
 
     public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
+++ b/statix.solver/src/main/java/mb/statix/solver/query/QueryMin.java
@@ -68,30 +68,30 @@ public class QueryMin implements Serializable {
      * Apply capture avoiding substitution.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryMin apply(ISubstitution.Immutable subst, boolean trackOrigin) {
-        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigin));
+    public QueryMin apply(ISubstitution.Immutable subst, boolean trackOrigins) {
+        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigins));
     }
 
     /**
      * Apply unguarded substitution, which may result in capture.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryMin unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
-        return new QueryMin(labelOrd, dataOrd.unsafeApply(subst, trackOrigin));
+    public QueryMin unsafeApply(ISubstitution.Immutable subst, boolean trackOrigins) {
+        return new QueryMin(labelOrd, dataOrd.unsafeApply(subst, trackOrigins));
     }
 
     /**
      * Apply variable renaming.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public QueryMin apply(IRenaming subst, boolean trackOrigin) {
-        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigin));
+    public QueryMin apply(IRenaming subst, boolean trackOrigins) {
+        return new QueryMin(labelOrd, dataOrd.apply(subst, trackOrigins));
     }
 
     public String toString(TermFormatter termToString) {

--- a/statix.solver/src/main/java/mb/statix/spec/ARule.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ARule.java
@@ -221,9 +221,9 @@ public abstract class ARule {
         ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges();
 
         params = params().stream().map(p -> p.apply(subst)).collect(ImList.Immutable.toImmutableList());
-        body = body.apply(subst);
+        body = body.apply(subst, trackOrigin);
         if(bodyCriticalEdges != null) {
-            bodyCriticalEdges = bodyCriticalEdges.apply(subst, trackOrigin);
+            bodyCriticalEdges = bodyCriticalEdges.apply(subst);
         }
 
         return Rule.of(name(), params, body).withBodyCriticalEdges(bodyCriticalEdges);

--- a/statix.solver/src/main/java/mb/statix/spec/ARule.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ARule.java
@@ -149,9 +149,9 @@ public abstract class ARule {
      * Apply capture avoiding substitution.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public Rule apply(ISubstitution.Immutable subst, boolean trackOrigin) {
+    public Rule apply(ISubstitution.Immutable subst, boolean trackOrigins) {
         ISubstitution.Immutable localSubst = subst.removeAll(paramVars()).retainAll(freeVars());
         if(localSubst.isEmpty()) {
             return (Rule) this;
@@ -176,7 +176,7 @@ public abstract class ARule {
             localSubst = ren.asSubstitution().compose(localSubst);
         }
 
-        body = body.apply(localSubst, trackOrigin);
+        body = body.apply(localSubst, trackOrigins);
         if(bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
@@ -188,9 +188,9 @@ public abstract class ARule {
      * Apply unguarded substitution, which may result in capture.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public Rule unsafeApply(ISubstitution.Immutable subst, boolean trackOrigin) {
+    public Rule unsafeApply(ISubstitution.Immutable subst, boolean trackOrigins) {
         ISubstitution.Immutable localSubst = subst.removeAll(paramVars());
         if(localSubst.isEmpty()) {
             return (Rule) this;
@@ -200,7 +200,7 @@ public abstract class ARule {
         IConstraint body = this.body();
         ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges();
 
-        body = body.unsafeApply(localSubst, trackOrigin);
+        body = body.unsafeApply(localSubst, trackOrigins);
         if(bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(localSubst);
         }
@@ -213,15 +213,15 @@ public abstract class ARule {
      * Apply variable renaming.
      *
      * @param subst the substitution to apply
-     * @param trackOrigin whether to track the syntactic origin of the constraints, if not already tracked
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
      */
-    public Rule apply(IRenaming subst, boolean trackOrigin) {
+    public Rule apply(IRenaming subst, boolean trackOrigins) {
         ImList.Immutable<Pattern> params = this.params();
         IConstraint body = this.body();
         ICompleteness.Immutable bodyCriticalEdges = this.bodyCriticalEdges();
 
         params = params().stream().map(p -> p.apply(subst)).collect(ImList.Immutable.toImmutableList());
-        body = body.apply(subst, trackOrigin);
+        body = body.apply(subst, trackOrigins);
         if(bodyCriticalEdges != null) {
             bodyCriticalEdges = bodyCriticalEdges.apply(subst);
         }

--- a/statix.solver/src/main/java/mb/statix/spec/ARule.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ARule.java
@@ -64,20 +64,28 @@ public abstract class ARule {
      */
     @Value.Lazy public Optional<Boolean> isAlways() throws InterruptedException {
         final List<ITermVar>
-            args = IntStream.range(0, params().size()).mapToObj(idx -> B.newVar("", "arg" + idx))
+                args = IntStream.range(0, params().size()).mapToObj(idx -> B.newVar("", "arg" + idx))
                 .collect(Collectors.toList());
         final ApplyResult applyResult;
         try {
-            if((applyResult = RuleUtil.apply(PersistentUniDisunifier.Immutable.of(), (Rule) this, args, null,
-                    ApplyMode.STRICT, Safety.SAFE).orElse(null)) == null) {
+            applyResult = RuleUtil.apply(
+                    PersistentUniDisunifier.Immutable.of(),
+                    (Rule)this,
+                    args,
+                    null,
+                    ApplyMode.STRICT,
+                    Safety.SAFE,
+                    false
+            ).orElse(null);
+            if (applyResult == null) {
                 // We could not apply the rule to the given variables,
                 // this rule is not unconditional
                 return Optional.empty();
             }
-        } catch(Delay d) {
+        } catch (Delay d) {
             return Optional.empty();
         }
-        if(applyResult.guard().isPresent()) {
+        if (applyResult.guard().isPresent()) {
             // This rule is not unconditional
             return Optional.empty();
         }

--- a/statix.solver/src/main/java/mb/statix/spec/ApplyMode.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ApplyMode.java
@@ -29,7 +29,13 @@ public abstract class ApplyMode<E extends Throwable> {
      */
     public static final ApplyMode<VoidException> RELAXED = new ApplyRelaxed();
 
-    abstract Optional<ApplyResult> apply(IUniDisunifier.Immutable unifier, Rule rule, List<? extends ITerm> args,
-            @Nullable IConstraint cause, Safety safety) throws E;
+    abstract Optional<ApplyResult> apply(
+            IUniDisunifier.Immutable unifier,
+            Rule rule,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            Safety safety,
+            boolean trackOrigins
+    ) throws E;
 
 }

--- a/statix.solver/src/main/java/mb/statix/spec/ApplyRelaxed.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ApplyRelaxed.java
@@ -27,10 +27,16 @@ import mb.statix.solver.completeness.ICompleteness;
 
 class ApplyRelaxed extends ApplyMode<VoidException> {
 
-    @Override Optional<ApplyResult> apply(IUniDisunifier.Immutable unifier, Rule rule, List<? extends ITerm> args,
-            IConstraint cause, Safety safety) throws VoidException {
+    @Override Optional<ApplyResult> apply(
+            IUniDisunifier.Immutable unifier,
+            Rule rule,
+            List<? extends ITerm> args,
+            IConstraint cause,
+            Safety safety,
+            boolean trackOrigins
+    ) throws VoidException {
         Set.Immutable<ITermVar> freeVars = rule.freeVars();
-        for(ITerm arg : args) {
+        for (ITerm arg : args) {
             freeVars = freeVars.__insertAll(arg.getVars());
         }
 
@@ -38,7 +44,7 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
         final FreshVars fresh = new FreshVars(freeVars);
         final VarProvider freshProvider = VarProvider.of(v -> fresh.fresh(v), () -> fresh.fresh("_"));
         final MatchResult matchResult;
-        if((matchResult = P.matchWithEqs(rule.params(), args, unifier, freshProvider).orElse(null)) == null) {
+        if ((matchResult = P.matchWithEqs(rule.params(), args, unifier, freshProvider).orElse(null)) == null) {
             return Optional.empty();
         }
 
@@ -49,10 +55,10 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
         final Set.Immutable<ITermVar> constrainedVars = Set.Immutable.subtract(matchResult.constrainedVars(), generatedVars);
 
         final IConstraint appliedBody;
-        if(safety.equals(Safety.UNSAFE)) {
-            appliedBody = rule.body().unsafeApply(matchResult.substitution(), true).withCause(cause);
+        if (safety.equals(Safety.UNSAFE)) {
+            appliedBody = rule.body().unsafeApply(matchResult.substitution(), trackOrigins).withCause(cause);
         } else {
-            appliedBody = rule.body().apply(matchResult.substitution(), true).withCause(cause);
+            appliedBody = rule.body().apply(matchResult.substitution(), trackOrigins).withCause(cause);
         }
         final ICompleteness.Immutable appliedCriticalEdges =
                 rule.bodyCriticalEdges() == null ? null : rule.bodyCriticalEdges().apply(matchResult.substitution());
@@ -60,10 +66,10 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
         // simplify guard constraints
         final IUniDisunifier.Result<IUnifier.Immutable> unifyResult;
         try {
-            if((unifyResult = unifier.unify(matchResult.equalities()).orElse(null)) == null) {
+            if ((unifyResult = unifier.unify(matchResult.equalities()).orElse(null)) == null) {
                 return Optional.empty();
             }
-        } catch(OccursException e) {
+        } catch (OccursException e) {
             return Optional.empty();
         }
         final IUnifier.Immutable diff = unifyResult.result();
@@ -73,7 +79,7 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
         final ICompleteness.Immutable newCriticalEdges;
         final Optional<Diseq> diseq;
         final IUnifier.Immutable guard = diff.retainAll(constrainedVars).unifier();
-        if(guard.isEmpty()) {
+        if (guard.isEmpty()) {
             newBody = appliedBody;
             newCriticalEdges = appliedCriticalEdges;
             diseq = Optional.empty();
@@ -88,8 +94,11 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
         }
 
         // construct result
-        final ApplyResult applyResult = ApplyResult.of(diseq, newBody,
-                newCriticalEdges != null ? newCriticalEdges : Completeness.Immutable.of());
+        final ApplyResult applyResult = ApplyResult.of(
+                diseq,
+                newBody,
+                newCriticalEdges != null ? newCriticalEdges : Completeness.Immutable.of()
+        );
 
         return Optional.of(applyResult);
     }

--- a/statix.solver/src/main/java/mb/statix/spec/ApplyRelaxed.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ApplyRelaxed.java
@@ -50,9 +50,9 @@ class ApplyRelaxed extends ApplyMode<VoidException> {
 
         final IConstraint appliedBody;
         if(safety.equals(Safety.UNSAFE)) {
-            appliedBody = rule.body().unsafeApply(matchResult.substitution()).withCause(cause);
+            appliedBody = rule.body().unsafeApply(matchResult.substitution(), true).withCause(cause);
         } else {
-            appliedBody = rule.body().apply(matchResult.substitution()).withCause(cause);
+            appliedBody = rule.body().apply(matchResult.substitution(), true).withCause(cause);
         }
         final ICompleteness.Immutable appliedCriticalEdges =
                 rule.bodyCriticalEdges() == null ? null : rule.bodyCriticalEdges().apply(matchResult.substitution());

--- a/statix.solver/src/main/java/mb/statix/spec/ApplyStrict.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ApplyStrict.java
@@ -15,23 +15,32 @@ import mb.statix.solver.completeness.ICompleteness;
 
 class ApplyStrict extends ApplyMode<Delay> {
 
-    @Override Optional<ApplyResult> apply(IUniDisunifier.Immutable unifier, Rule rule, List<? extends ITerm> args,
-            IConstraint cause, Safety safety) throws Delay {
-        final ISubstitution.Immutable subst;
-        if((subst =
-                P.match(rule.params(), args, unifier).orElseThrow(vars -> Delay.ofVars(vars)).orElse(null)) == null) {
+    @Override Optional<ApplyResult> apply(
+            IUniDisunifier.Immutable unifier,
+            Rule rule,
+            List<? extends ITerm> args,
+            IConstraint cause,
+            Safety safety,
+            boolean trackOrigins
+    ) throws Delay {
+        final ISubstitution.Immutable subst = P.match(rule.params(), args, unifier)
+                .orElseThrow(vars -> Delay.ofVars(vars)).orElse(null);
+        if (subst == null) {
             return Optional.empty();
         }
         final IConstraint newBody;
-        if(safety.equals(Safety.UNSAFE)) {
-            newBody = rule.body().unsafeApply(subst, true).withCause(cause);
+        if (safety.equals(Safety.UNSAFE)) {
+            newBody = rule.body().unsafeApply(subst, trackOrigins).withCause(cause);
         } else {
-            newBody = rule.body().apply(subst, true).withCause(cause);
+            newBody = rule.body().apply(subst, trackOrigins).withCause(cause);
         }
         final ICompleteness.Immutable newBodyCriticalEdges =
                 rule.bodyCriticalEdges() == null ? null : rule.bodyCriticalEdges().apply(subst);
-        final ApplyResult applyResult = ApplyResult.of(Optional.empty(), newBody,
-                newBodyCriticalEdges != null ? newBodyCriticalEdges : Completeness.Immutable.of());
+        final ApplyResult applyResult = ApplyResult.of(
+                Optional.empty(),
+                newBody,
+                newBodyCriticalEdges != null ? newBodyCriticalEdges : Completeness.Immutable.of()
+        );
         return Optional.of(applyResult);
     }
 

--- a/statix.solver/src/main/java/mb/statix/spec/ApplyStrict.java
+++ b/statix.solver/src/main/java/mb/statix/spec/ApplyStrict.java
@@ -24,9 +24,9 @@ class ApplyStrict extends ApplyMode<Delay> {
         }
         final IConstraint newBody;
         if(safety.equals(Safety.UNSAFE)) {
-            newBody = rule.body().unsafeApply(subst).withCause(cause);
+            newBody = rule.body().unsafeApply(subst, true).withCause(cause);
         } else {
-            newBody = rule.body().apply(subst).withCause(cause);
+            newBody = rule.body().apply(subst, true).withCause(cause);
         }
         final ICompleteness.Immutable newBodyCriticalEdges =
                 rule.bodyCriticalEdges() == null ? null : rule.bodyCriticalEdges().apply(subst);

--- a/statix.solver/src/main/java/mb/statix/spec/IndexedRuleApplication.java
+++ b/statix.solver/src/main/java/mb/statix/spec/IndexedRuleApplication.java
@@ -39,7 +39,7 @@ import mb.statix.spec.ApplyMode.Safety;
 /**
  * A special rule application that supports indexing in its parameters. The index allows grouping based on which
  * arguments match a constraint, and finding matching arguments using lookup.
- * 
+ * <p>
  * The class throws Delay exceptions in the following cases:
  * <ul>
  * <li>If the initial application does not reduce enough, and the remaining constraint has free variables left. The free
@@ -154,29 +154,36 @@ public class IndexedRuleApplication {
 
         final IState.Transient _state = state.melt();
         final List<ITermVar> args = new ArrayList<>();
-        for(@SuppressWarnings("unused") Pattern param : rule.params()) {
+        for (@SuppressWarnings("unused") Pattern param : rule.params()) {
             final ITermVar v = _state.freshVar(B.newVar("", "arg"));
             args.add(v);
         }
         final IState.Immutable newState = _state.freeze();
 
-        final ApplyResult applyResult;
-        if((applyResult = RuleUtil.apply(newState.unifier(), rule, args, null, ApplyMode.RELAXED, Safety.SAFE)
-                .orElse(null)) == null) {
+        final ApplyResult applyResult = RuleUtil.apply(
+                newState.unifier(),
+                rule,
+                args,
+                null,
+                ApplyMode.RELAXED,
+                Safety.SAFE,
+                true
+        ).orElse(null);
+        if (applyResult == null) {
             return Optional.empty();
         }
 
         final IConstraint bodyAsConstraint = applyResult.body();
-        final SolverResult solveResult = Solver.solve(spec, newState, bodyAsConstraint, new NullDebugContext(),
+        final SolverResult<?> solveResult = Solver.solve(spec, newState, bodyAsConstraint, new NullDebugContext(),
                 new NullCancel(), new NullProgress(), Solver.RETURN_ON_FIRST_ERROR);
-        if(solveResult.hasErrors()) {
+        if (solveResult.hasErrors()) {
             return Optional.empty();
         }
 
         final SortedSet<ITermVar> indexVars = new TreeSet<>();
         final List<Pattern> newParams = new ArrayList<>();
         final java.util.Set<ITermVar> newParamVars = new HashSet<>();
-        for(ITermVar arg : args) {
+        for (ITermVar arg : args) {
             final ITerm term = solveResult.state().unifier().findRecursive(arg);
             final Immutable<ITermVar> termVars = term.getVars();
             final Pattern param = P.fromTerm(term);
@@ -188,12 +195,12 @@ public class IndexedRuleApplication {
         final ITerm index = B.newTuple(indexVars);
 
         final IndexedRuleApplication ira;
-        if(solveResult.delays().isEmpty()) {
+        if (solveResult.delays().isEmpty()) {
             ira = new IndexedRuleApplication(spec, newParams, null, index);
         } else {
             final IConstraint residualConstraint = solveResult.delayed();
             final Set.Immutable<ITermVar> newFreeVars = residualConstraint.freeVars().__removeAll(newParamVars);
-            if(!newFreeVars.isEmpty()) {
+            if (!newFreeVars.isEmpty()) {
                 throw Delay.ofVars(newFreeVars);
             }
             ira = new IndexedRuleApplication(spec, newParams, residualConstraint, index);

--- a/statix.solver/src/main/java/mb/statix/spec/IndexedRuleApplication.java
+++ b/statix.solver/src/main/java/mb/statix/spec/IndexedRuleApplication.java
@@ -174,7 +174,7 @@ public class IndexedRuleApplication {
         }
 
         final IConstraint bodyAsConstraint = applyResult.body();
-        final SolverResult<?> solveResult = Solver.solve(spec, newState, bodyAsConstraint, new NullDebugContext(),
+        final SolverResult solveResult = Solver.solve(spec, newState, bodyAsConstraint, new NullDebugContext(),
                 new NullCancel(), new NullProgress(), Solver.RETURN_ON_FIRST_ERROR);
         if (solveResult.hasErrors()) {
             return Optional.empty();

--- a/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
+++ b/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
@@ -48,7 +48,8 @@ import mb.statix.solver.IConstraint;
 import mb.statix.solver.StateUtil;
 import mb.statix.spec.ApplyMode.Safety;
 
-public class RuleUtil {
+public final class RuleUtil {
+    private RuleUtil() { /* This class cannot be instantiated. */ }
 
     /**
      * Apply the given list of rules to the given arguments. Returns the result of application if one rule can be
@@ -56,23 +57,25 @@ public class RuleUtil {
      * order, with the first rule that can be applied is selected if the match is unconditional, or it is the only rule
      * that can be applied.
      *
-     * @param state
-     *            Initial state
-     * @param rules
-     *            Ordered list of rules to apply
-     * @param args
-     *            Arguments to apply the rules to
-     * @param cause
-     *            Cause of this rule application, null if none
-     *
-     * @return Empty if no rules apply, or the first application if multiple rules apply. The third component of the
-     *         tuple is true if this is the only match.
+     * @param state        the initial state
+     * @param rules        an ordered list of rules to apply
+     * @param args         the arguments to apply the rules to
+     * @param cause        the cause of this rule application; or {@code null} if none
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
+     * @return none if no rules apply, or the first application if multiple rules apply. The third component of the
+     * tuple is true if this is the only match.
      */
     public static <E extends Throwable> Optional<Tuple3<Rule, ApplyResult, Boolean>> applyOrderedOne(
-            IUniDisunifier.Immutable state, ImList.Immutable<Rule> rules, List<? extends ITerm> args, @Nullable IConstraint cause,
-            ApplyMode<E> mode, Safety safety) throws E {
-        final List<Tuple2<Rule, ApplyResult>> results = applyOrdered(state, rules, args, cause, mode, safety, true);
-        if(results.size() == 0) {
+            IUniDisunifier.Immutable state,
+            ImList.Immutable<Rule> rules,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety,
+            boolean trackOrigins
+    ) throws E {
+        final List<Tuple2<Rule, ApplyResult>> results = applyOrdered(state, rules, args, cause, mode, safety, true, trackOrigins);
+        if (results.size() == 0) {
             return Optional.empty();
         } else {
             final Tuple2<Rule, ApplyResult> result = results.get(0);
@@ -85,54 +88,63 @@ public class RuleUtil {
      * are expected to be in matching order, with rules being selected up to and including the first rule that can be
      * applied unconditional.
      *
-     * @param state
-     *            Initial state
-     * @param rules
-     *            Ordered list of rules to apply
-     * @param args
-     *            Arguments to apply the rules to
-     * @param cause
-     *            Cause of this rule application, null if none
-     *
-     * @return A list of apply results, up to and including the first unconditionally matching result.
+     * @param state        the initial state
+     * @param rules        an ordered list of rules to apply
+     * @param args         the arguments to apply the rules to
+     * @param cause        the cause of this rule application; or {@code null} if none
+     * @param trackOrigins whether to track the syntactic origin of the constraints, if not already tracked
+     * @return a list of apply results, up to and including the first unconditionally matching result.
      */
-    public static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyOrderedAll(IUniDisunifier.Immutable state,
-            ImList.Immutable<Rule> rules, List<? extends ITerm> args, @Nullable IConstraint cause, ApplyMode<E> mode, Safety safety)
-            throws E {
-        return applyOrdered(state, rules, args, cause, mode, safety, false);
+    public static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyOrderedAll(
+            IUniDisunifier.Immutable state,
+            ImList.Immutable<Rule> rules,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety,
+            boolean trackOrigins
+    ) throws E {
+        return applyOrdered(state, rules, args, cause, mode, safety, false, trackOrigins);
     }
 
     /**
      * Helper method to apply the given list of ordered rules to the given arguments. Returns a list of results for all
      * rules that could be applied. If onlyOne is true, returns at most two results.
      */
-    private static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyOrdered(IUniDisunifier.Immutable unifier,
-            ImList.Immutable<Rule> rules, List<? extends ITerm> args, @Nullable IConstraint cause, ApplyMode<E> mode, Safety safety,
-            boolean onlyOne) throws E {
+    private static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyOrdered(
+            IUniDisunifier.Immutable unifier,
+            ImList.Immutable<Rule> rules,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety,
+            boolean onlyOne,
+            boolean trackOrigins
+    ) throws E {
         final ImList.Mutable<Tuple2<Rule, ApplyResult>> results = ImList.Mutable.of();
         final AtomicBoolean foundOne = new AtomicBoolean(false);
-        for(Rule rule : rules) {
+        for (Rule rule : rules) {
             // apply rule
             final ApplyResult applyResult;
-            if((applyResult = apply(unifier, rule, args, cause, mode, safety).orElse(null)) == null) {
+            if ((applyResult = apply(unifier, rule, args, cause, mode, safety, trackOrigins).orElse(null)) == null) {
                 // this rule does not apply, continue to next rules
                 continue;
             }
             results.add(Tuple2.of(rule, applyResult));
-            if(onlyOne && foundOne.getAndSet(true)) {
+            if (onlyOne && foundOne.getAndSet(true)) {
                 // we require exactly one, but found multiple
                 break;
             }
 
             // stop or add guard to state for next rule
             final Tuple3<Set<ITermVar>, ITerm, ITerm> guard;
-            if((guard = applyResult.guard().map(Diseq::toTuple).orElse(null)) == null) {
+            if ((guard = applyResult.guard().map(Diseq::toTuple).orElse(null)) == null) {
                 // next rules are unreachable after this unconditional match
                 break;
             }
             final Optional<IUniDisunifier.Immutable> newUnifier =
                     unifier.disunify(guard._1(), guard._2(), guard._3()).map(IUniDisunifier.Result::unifier);
-            if(!newUnifier.isPresent()) {
+            if (!newUnifier.isPresent()) {
                 // guards are equalities missing in the unifier, disunifying them should never fail
                 throw new IllegalStateException("Unexpected incompatible guard.");
             }
@@ -145,21 +157,34 @@ public class RuleUtil {
      * Apply the given rule to the given arguments. Returns the result of application, or nothing of the rule cannot be
      * applied. The result may contain equalities that need to be satisfied for the application to be valid.
      */
-    public static <E extends Throwable> Optional<ApplyResult> apply(IUniDisunifier.Immutable unifier, Rule rule,
-            List<? extends ITerm> args, @Nullable IConstraint cause, ApplyMode<E> mode, Safety safety) throws E {
-        return mode.apply(unifier, rule, args, cause, safety);
+    public static <E extends Throwable> Optional<ApplyResult> apply(
+            IUniDisunifier.Immutable unifier,
+            Rule rule,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety,
+            boolean trackOrigins
+    ) throws E {
+        return mode.apply(unifier, rule, args, cause, safety, trackOrigins);
     }
 
     /**
      * Apply the given rules to the given arguments. Returns the results of application.
      */
-    public static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyAll(IUniDisunifier.Immutable state,
-            Collection<Rule> rules, List<? extends ITerm> args, @Nullable IConstraint cause, ApplyMode<E> mode,
-            Safety safety) throws E {
+    public static <E extends Throwable> List<Tuple2<Rule, ApplyResult>> applyAll(
+            IUniDisunifier.Immutable state,
+            Collection<Rule> rules,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety,
+            boolean trackOrigins
+    ) throws E {
         final ImList.Mutable<Tuple2<Rule, ApplyResult>> results = ImList.Mutable.of();
-        for(Rule rule : rules) {
+        for (Rule rule : rules) {
             final ApplyResult result;
-            if((result = apply(state, rule, args, cause, mode, safety).orElse(null)) != null) {
+            if ((result = apply(state, rule, args, cause, mode, safety, trackOrigins).orElse(null)) != null) {
                 results.add(Tuple2.of(rule, result));
             }
         }
@@ -169,28 +194,28 @@ public class RuleUtil {
     /**
      * Computes the order independent rules.
      *
-     * @param rules
-     *            the ordered set of rules for which to compute
+     * @param rules the ordered set of rules for which to compute
      * @return the set of order independent rules
      */
     public static Set.Immutable<Rule> computeOrderIndependentRules(ImList.Immutable<Rule> rules) {
         final Set.Transient<Rule> newRules = CapsuleUtil.transientSet();
         final List<Tuple3<Set.Immutable<ITermVar>, ITerm, IUnifier.Immutable>> guards = new ArrayList<>();
-        RULE: for(Rule rule : rules) {
+        RULE:
+        for (Rule rule : rules) {
             final Set.Immutable<ITermVar> ruleParamVars = rule.paramVars();
             final FreshVars fresh = new FreshVars(rule.freeVars(), ruleParamVars);
 
             final List<ITerm> paramTerms = new ArrayList<>();
             final IUniDisunifier.Transient _paramsUnifier = PersistentUniDisunifier.Immutable.of().melt();
-            for(Pattern param : rule.params()) {
+            for (Pattern param : rule.params()) {
                 final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> paramTerm =
                         param.asTerm(v -> v.orElseGet(() -> fresh.fresh("_")));
                 paramTerms.add(paramTerm._1());
                 try {
-                    if(!_paramsUnifier.unify(paramTerm._2()).isPresent()) {
+                    if (!_paramsUnifier.unify(paramTerm._2()).isPresent()) {
                         continue RULE; // skip, unmatchable pattern
                     }
-                } catch(OccursException ex) {
+                } catch (OccursException ex) {
                     continue RULE; // skip, unmatchable pattern
                 }
             }
@@ -199,20 +224,21 @@ public class RuleUtil {
             final IUniDisunifier.Immutable paramsUnifier = _paramsUnifier.freeze();
 
             final IUniDisunifier.Transient _unifier = paramsUnifier.melt();
-            GUARD: for(Tuple3<Set.Immutable<ITermVar>, ITerm, IUnifier.Immutable> guard : guards) {
+            GUARD:
+            for (Tuple3<Set.Immutable<ITermVar>, ITerm, IUnifier.Immutable> guard : guards) {
                 final IRenaming guardRen = fresh.fresh(guard._1());
                 final Set.Immutable<ITermVar> guardVars = fresh.reset();
                 final ITerm guardTerm = guardRen.apply(guard._2());
                 IUnifier.Immutable guardUnifier = guard._3().rename(guardRen);
                 try {
-                    if((guardUnifier =
+                    if ((guardUnifier =
                             guardUnifier.unify(paramsTerm, guardTerm).map(r -> r.unifier()).orElse(null)) == null) {
                         continue GUARD; // skip, guard already satisfied
                     }
-                } catch(OccursException ex) {
+                } catch (OccursException ex) {
                     continue GUARD; // skip, guard already satisfied
                 }
-                if(!_unifier.disunify(guardVars, guardUnifier).isPresent()) {
+                if (!_unifier.disunify(guardVars, guardUnifier).isPresent()) {
                     continue RULE; // skip, incompatible patterns & guards
                 }
             }
@@ -233,11 +259,11 @@ public class RuleUtil {
                     Constraints.exists(newBodyVars, Constraints.conjoin(StateUtil.asConstraint(unifier), rule.body()));
 
             final Rule newRule = Rule.builder()
-                .from(rule)
-                .params(params)
-                .body(body)
-                .bodyCriticalEdges(rule.bodyCriticalEdges())
-                .build();
+                    .from(rule)
+                    .params(params)
+                    .body(body)
+                    .bodyCriticalEdges(rule.bodyCriticalEdges())
+                    .build();
 
             newRules.__insert(newRule);
         }
@@ -254,21 +280,21 @@ public class RuleUtil {
 
         final AtomicInteger i = new AtomicInteger(0);
         final IConstraint newBody = Constraints.map(c -> {
-            if(!(c instanceof CUser)) {
+            if (!(c instanceof CUser)) {
                 return c;
             }
-            final CUser constraint = (CUser) c;
-            if(!constraint.name().equals(rule.name())) {
+            final CUser constraint = (CUser)c;
+            if (!constraint.name().equals(rule.name())) {
                 return c;
             }
-            if(i.getAndIncrement() != ith) {
+            if (i.getAndIncrement() != ith) {
                 return c;
             }
 
             return applyToConstraint(fresh, rule, constraint.args());
         }, false).apply(into.body());
 
-        if(i.get() <= ith) {
+        if (i.get() <= ith) {
             // nothing was inlined
             return Optional.empty();
         }
@@ -290,9 +316,9 @@ public class RuleUtil {
 
     /**
      * Transform rule such that constraints and have a single top-level existential.
-     *
+     * <p>
      * Head patterns are preserved.
-     *
+     * <p>
      * For example:
      *
      * <pre>
@@ -307,7 +333,7 @@ public class RuleUtil {
     /**
      * Transform rule such that head patterns are maximally instantiated based on the body. This implicitly applies
      * hoisting.
-     *
+     * <p>
      * Head patterns are not preserved, but may only become more specific.
      */
     public static Rule instantiateHeadPatterns(Rule rule) {
@@ -316,15 +342,15 @@ public class RuleUtil {
 
         final List<ITerm> paramTerms = new ArrayList<>();
         final IUniDisunifier.Transient _paramsUnifier = PersistentUniDisunifier.Immutable.of().melt();
-        for(Pattern param : rule.params()) {
+        for (Pattern param : rule.params()) {
             final Tuple2<ITerm, List<Tuple2<ITermVar, ITerm>>> paramTerm =
                     param.asTerm(v -> v.orElseGet(() -> fresh.fresh("_")));
             paramTerms.add(paramTerm._1());
             try {
-                if(!_paramsUnifier.unify(paramTerm._2()).isPresent()) {
+                if (!_paramsUnifier.unify(paramTerm._2()).isPresent()) {
                     return rule; // skip, unmatchable pattern
                 }
-            } catch(OccursException ex) {
+            } catch (OccursException ex) {
                 return rule; // skip, unmatchable pattern
             }
         }
@@ -340,7 +366,7 @@ public class RuleUtil {
 
         final List<ITerm> newParamTerms = new ArrayList<>();
         final MultiSet.Transient<ITermVar> newParamVars = MultiSet.Transient.of();
-        for(ITerm paramTerm : paramTerms) {
+        for (ITerm paramTerm : paramTerms) {
             final ITerm newParamTerm = externResult._1().apply(paramTerm);
             newParamTerms.add(newParamTerm);
             newParamTerm.visitVars(newParamVars::add);
@@ -359,11 +385,11 @@ public class RuleUtil {
      */
     public static Rule closeInUnifier(Rule rule, IUnifier.Immutable unifier, Safety safety) {
         ISubstitution.Immutable subst = PersistentSubstitution.Immutable.of();
-        for(ITermVar var : rule.freeVars()) {
+        for (ITermVar var : rule.freeVars()) {
             subst = subst.put(var, unifier.findRecursive(var));
         }
         Rule newRule;
-        if(safety.equals(Safety.UNSAFE)) {
+        if (safety.equals(Safety.UNSAFE)) {
             newRule = rule.unsafeApply(subst);
         } else {
             newRule = rule.apply(subst);
@@ -378,15 +404,15 @@ public class RuleUtil {
      * predicates.
      */
     public static SetMultimap.Immutable<String, Rule> makeFragments(RuleSet rules, Predicate1<String> includePredicate,
-            Predicate2<String, String> includeRule, int generations) {
+                                                                    Predicate2<String, String> includeRule, int generations) {
         final SetMultimap.Transient<String, Rule> fragments = SetMultimap.Transient.of();
 
         // 1. make all rules unordered, and keep included rules
         final SetMultimap.Transient<String, Rule> newRules = SetMultimap.Transient.of();
-        for(String ruleName : rules.getRuleNames()) {
-            if(includePredicate.test(ruleName)) {
-                for(Rule r : rules.getOrderIndependentRules(ruleName)) {
-                    if(includeRule.test(r.name(), r.label())) {
+        for (String ruleName : rules.getRuleNames()) {
+            if (includePredicate.test(ruleName)) {
+                for (Rule r : rules.getOrderIndependentRules(ruleName)) {
+                    if (includeRule.test(r.name(), r.label())) {
                         newRules.__insert(ruleName, r);
                     }
                 }
@@ -394,34 +420,34 @@ public class RuleUtil {
         }
 
         final PartialFunction1<IConstraint, CUser> expandable =
-                c -> (c instanceof CUser && newRules.containsKey(((CUser) c).name())) ? Optional.of(((CUser) c))
+                c -> (c instanceof CUser && newRules.containsKey(((CUser)c).name())) ? Optional.of(((CUser)c))
                         : Optional.empty();
 
         // 2. find the included axioms and move to fragments
-        for(Map.Entry<String, Rule> e : newRules.entrySet()) {
-            if(Constraints.collectBase(expandable, false).apply(e.getValue().body()).isEmpty()) {
+        for (Map.Entry<String, Rule> e : newRules.entrySet()) {
+            if (Constraints.collectBase(expandable, false).apply(e.getValue().body()).isEmpty()) {
                 fragments.__insert(e.getKey(), e.getValue());
             }
         }
         fragments.entrySet().forEach(e -> newRules.__remove(e.getKey(), e.getValue()));
 
         // 3. for each generation, inline fragments into rules
-        for(int g = 0; g < generations; g++) {
+        for (int g = 0; g < generations; g++) {
             final SetMultimap.Transient<String, Rule> generation = SetMultimap.Transient.of();
-            for(Map.Entry<String, Rule> e : newRules.entrySet()) {
+            for (Map.Entry<String, Rule> e : newRules.entrySet()) {
                 final String name = e.getKey();
                 final Rule r = e.getValue();
                 final FreshVars fresh = new FreshVars(vars(r));
                 final List<IConstraint> cs = Constraints.flatMap(c -> {
                     final Optional<CUser> u = expandable.apply(c);
-                    if(u.isPresent()) {
+                    if (u.isPresent()) {
                         return fragments.get(u.get().name()).stream()
                                 .map(f -> applyToConstraint(fresh, f, u.get().args()));
                     } else {
                         return Stream.of(c);
                     }
                 }, false).apply(r.body()).collect(Collectors.toList());
-                for(IConstraint c : cs) {
+                for (IConstraint c : cs) {
                     final Rule f = r.withLabel("").withBody(new CExists(CapsuleUtil.immutableSet(), c));
                     generation.__insert(name, hoist(f));
                 }

--- a/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
+++ b/statix.solver/src/main/java/mb/statix/spec/RuleUtil.java
@@ -153,6 +153,18 @@ public final class RuleUtil {
         return results.freeze();
     }
 
+    // TODO: Remove this overload
+    public static <E extends Throwable> Optional<ApplyResult> apply(
+            IUniDisunifier.Immutable unifier,
+            Rule rule,
+            List<? extends ITerm> args,
+            @Nullable IConstraint cause,
+            ApplyMode<E> mode,
+            Safety safety
+    ) throws E {
+        return apply(unifier, rule, args, cause, mode, safety, false);
+    }
+
     /**
      * Apply the given rule to the given arguments. Returns the result of application, or nothing of the rule cannot be
      * applied. The result may contain equalities that need to be satisfied for the application to be valid.


### PR DESCRIPTION
This PR adds an `origin` field to constraints, tracking the syntactic constraint to which substitutions were applied that resulted in the current constraint.